### PR TITLE
Align executive dashboard expense ratio with budget summary

### DIFF
--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_executive_dashboard.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_executive_dashboard.sql
@@ -14,7 +14,7 @@ WITH latest_period AS (
 ),
 
 current_month_summary AS (
-  SELECT 
+  SELECT
     ms.budget_year_month,
     ms.budget_year,
     ms.budget_month,
@@ -22,6 +22,7 @@ current_month_summary AS (
     ms.total_expenses,
     ms.net_cash_flow,
     ms.savings_rate_percent,
+    ms.expense_ratio_percent,
     ms.rolling_3m_avg_income,
     ms.rolling_3m_avg_expenses,
     ms.ytd_income,
@@ -158,8 +159,8 @@ executive_summary AS (
     ccf.cash_flow_efficiency_percentile,
     ccf.cash_flow_status_compound,
     ROUND(ccf.cash_flow_efficiency_score, 0) AS cash_flow_score,
-    ROUND(ccf.outflow_to_inflow_ratio, 1) AS expense_to_income_ratio,
-    ROUND((ccf.outflow_to_inflow_ratio * 100)::numeric, 1) AS expense_to_income_ratio_pct,
+    ROUND(cms.expense_ratio_percent, 3) AS expense_to_income_ratio,
+    ROUND((cms.expense_ratio_percent * 100)::numeric, 1) AS expense_to_income_ratio_pct,
     ROUND((ccf.cash_flow_efficiency_percentile * 100)::numeric, 1) AS cash_flow_efficiency_percentile_pct,
     
     -- PERFORMANCE SCORES (Weighted Average)


### PR DESCRIPTION
The expense_to_income_ratio in rpt_executive_dashboard was using outflow_to_inflow_ratio from cash flow analysis, which includes financial services (mortgage interest, service fees). This caused a 25% discrepancy with rpt_monthly_budget_summary which excludes financial services via the metric_expense macro.

Now both models use the same expense_ratio_percent calculation, fixing test_metric_consistency_exec_vs_mbs.