### PR TITLE
Add order-level context to Amazon and Grocery dashboards

### DIFF
--- a/grafana/provisioning/dashboards/amazon-spending-dashboard.json
+++ b/grafana/provisioning/dashboards/amazon-spending-dashboard.json
@@ -125,6 +125,133 @@
                 "value": null
               }
             ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "reduceOptions": {
+          "values": true,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "vertical",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT order_count as \"Order Count\", ROUND(average_order_value, 2) as \"Avg Order Value\", ROUND(largest_order_value, 2) as \"Largest Order\" FROM reporting.viz_amazon_order_context ORDER BY year_month DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Order Context (Latest Month)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "displayMode": "basic",
+            "orientation": "horizontal"
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "reduceOptions": {
+          "values": true,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "vertical",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT ROUND(COALESCE(recurring_spend, 0), 2) as \"Recurring Spend\", ROUND(COALESCE(oneoff_spend, 0), 2) as \"One-Off Spend\" FROM reporting.viz_amazon_order_context ORDER BY year_month DESC LIMIT 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Recurring vs One-Off (Latest Month)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "displayMode": "basic",
+            "orientation": "horizontal"
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "currencyUSD"
         },
@@ -272,6 +399,94 @@
         }
       ],
       "title": "Amazon Spending Trends Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Average Order Value",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 11,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT year_month as time, average_order_value as \"Average Order Value\", previous_month_aov as \"Previous Month AOV\" FROM reporting.viz_amazon_order_context WHERE year_month >= NOW() - INTERVAL '18 months' ORDER BY year_month",
+          "refId": "A"
+        }
+      ],
+      "title": "Basket Size Trend (Price Inflation/Volume)",
       "type": "timeseries"
     },
     {

--- a/grafana/provisioning/dashboards/grocery-spending-dashboard.json
+++ b/grafana/provisioning/dashboards/grocery-spending-dashboard.json
@@ -603,6 +603,221 @@
       ],
       "title": "18-Month Grocery Market Share Trends (100% Stacked)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "displayMode": "basic",
+            "orientation": "horizontal"
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 54
+      },
+      "id": 8,
+      "options": {
+        "reduceOptions": {
+          "values": true,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "vertical",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT grocery_store, order_count as \"Order Count\", ROUND(average_order_value, 2) as \"Avg Order Value\", ROUND(largest_order_value, 2) as \"Largest Order\" FROM reporting.viz_grocery_order_context WHERE year_month = (SELECT MAX(year_month) FROM reporting.viz_grocery_order_context) ORDER BY grocery_store",
+          "refId": "A"
+        }
+      ],
+      "title": "Order Context by Store (Latest Month)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "displayMode": "basic",
+            "orientation": "horizontal"
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 54
+      },
+      "id": 9,
+      "options": {
+        "reduceOptions": {
+          "values": true,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "vertical",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT grocery_store, ROUND(COALESCE(recurring_spend, 0), 2) as \"Recurring Spend\", ROUND(COALESCE(oneoff_spend, 0), 2) as \"One-Off Spend\" FROM reporting.viz_grocery_order_context WHERE year_month = (SELECT MAX(year_month) FROM reporting.viz_grocery_order_context) ORDER BY grocery_store",
+          "refId": "A"
+        }
+      ],
+      "title": "Recurring vs One-Off by Store (Latest Month)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "insertNulls": false,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "Average Order Value",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 62
+      },
+      "id": 10,
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        },
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT year_month as time, grocery_store, average_order_value FROM reporting.viz_grocery_order_context WHERE year_month >= NOW() - INTERVAL '18 months' ORDER BY grocery_store, year_month",
+          "refId": "A"
+        }
+      ],
+      "title": "Basket Size Trend by Store (Price Inflation/Volume)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5m",

--- a/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
@@ -1,0 +1,84 @@
+{{ config(materialized='table') }}
+
+WITH amazon_transactions AS (
+    SELECT
+        ft.transaction_date,
+        CASE WHEN ft.transaction_amount < 0 THEN -ft.transaction_amount ELSE ft.transaction_amount END AS abs_amount,
+        ft.transaction_memo,
+        dc.category,
+        dc.subcategory,
+        DATE_TRUNC('month', ft.transaction_date) AS year_month,
+        -- Simple heuristic: Amazon subscriptions/recurring typically have specific keywords
+        CASE
+            WHEN LOWER(ft.transaction_memo) LIKE '%prime%'
+                OR LOWER(ft.transaction_memo) LIKE '%subscribe%'
+                OR LOWER(ft.transaction_memo) LIKE '%recurring%'
+                OR LOWER(ft.transaction_memo) LIKE '%membership%'
+            THEN 'Subscription/Recurring'
+            ELSE 'One-Off Purchase'
+        END AS purchase_type
+    FROM {{ ref('fct_transactions') }} ft
+    LEFT JOIN {{ ref('dim_categories') }} dc ON ft.category_key = dc.category_key
+    WHERE
+        ft.transaction_amount < 0  -- Only expenses (negative amounts)
+        AND LOWER(ft.transaction_memo) LIKE '%amazon%'
+),
+
+period_stats AS (
+    SELECT
+        year_month,
+        COUNT(DISTINCT transaction_date) AS order_count,
+        ROUND(AVG(abs_amount), 2) AS average_order_value,
+        MAX(abs_amount) AS largest_order_value,
+        MIN(abs_amount) AS smallest_order_value,
+        SUM(abs_amount) AS total_spend
+    FROM amazon_transactions
+    GROUP BY year_month
+),
+
+purchase_type_split AS (
+    SELECT
+        year_month,
+        purchase_type,
+        COUNT(*) AS transaction_count,
+        SUM(abs_amount) AS category_spend,
+        ROUND(AVG(abs_amount), 2) AS avg_amount
+    FROM amazon_transactions
+    GROUP BY year_month, purchase_type
+),
+
+basket_size_trend AS (
+    SELECT
+        year_month,
+        order_count,
+        average_order_value,
+        LAG(average_order_value, 1) OVER (ORDER BY year_month) AS previous_month_aov,
+        CASE
+            WHEN LAG(average_order_value, 1) OVER (ORDER BY year_month) > 0 THEN
+                ROUND(((average_order_value - LAG(average_order_value, 1) OVER (ORDER BY year_month)) /
+                       LAG(average_order_value, 1) OVER (ORDER BY year_month)) * 100, 1)
+            ELSE NULL
+        END AS aov_mom_change_percent,
+        LAG(order_count, 12) OVER (ORDER BY year_month) AS same_month_last_year_orders
+    FROM period_stats
+)
+
+SELECT
+    bst.year_month,
+    bst.order_count,
+    bst.average_order_value,
+    (SELECT largest_order_value FROM period_stats ps WHERE ps.year_month = bst.year_month) AS largest_order_value,
+    bst.previous_month_aov,
+    bst.aov_mom_change_percent,
+    bst.same_month_last_year_orders,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.category_spend ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS recurring_spend,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.category_spend ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS oneoff_spend,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.transaction_count ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS recurring_count,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.transaction_count ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS oneoff_count,
+    (SELECT total_spend FROM period_stats ps WHERE ps.year_month = bst.year_month) AS total_monthly_spend
+FROM basket_size_trend bst
+ORDER BY year_month DESC

--- a/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
@@ -25,6 +25,10 @@ WITH amazon_transactions AS (
 ),
 
 amazon_orders AS (
+    -- Group transactions by date as a proxy for orders
+    -- Note: This assumes one order per day. Multiple same-day purchases will be
+    -- aggregated into a single order with combined amounts.
+    -- This is a limitation of not having explicit order IDs in the transaction data.
     SELECT
         transaction_date::date AS order_date,
         DATE_TRUNC('month', transaction_date) AS year_month,

--- a/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_amazon_order_context.sql
@@ -24,15 +24,25 @@ WITH amazon_transactions AS (
         AND LOWER(ft.transaction_memo) LIKE '%amazon%'
 ),
 
+amazon_orders AS (
+    SELECT
+        transaction_date::date AS order_date,
+        DATE_TRUNC('month', transaction_date) AS year_month,
+        purchase_type,
+        SUM(abs_amount) AS order_amount
+    FROM amazon_transactions
+    GROUP BY transaction_date::date, DATE_TRUNC('month', transaction_date), purchase_type
+),
+
 period_stats AS (
     SELECT
         year_month,
-        COUNT(DISTINCT transaction_date) AS order_count,
-        ROUND(AVG(abs_amount), 2) AS average_order_value,
-        MAX(abs_amount) AS largest_order_value,
-        MIN(abs_amount) AS smallest_order_value,
-        SUM(abs_amount) AS total_spend
-    FROM amazon_transactions
+        COUNT(*) AS order_count,
+        ROUND(AVG(order_amount), 2) AS average_order_value,
+        MAX(order_amount) AS largest_order_value,
+        MIN(order_amount) AS smallest_order_value,
+        SUM(order_amount) AS total_spend
+    FROM amazon_orders
     GROUP BY year_month
 ),
 
@@ -40,10 +50,10 @@ purchase_type_split AS (
     SELECT
         year_month,
         purchase_type,
-        COUNT(*) AS transaction_count,
-        SUM(abs_amount) AS category_spend,
-        ROUND(AVG(abs_amount), 2) AS avg_amount
-    FROM amazon_transactions
+        COUNT(*) AS order_count,
+        SUM(order_amount) AS category_spend,
+        ROUND(AVG(order_amount), 2) AS avg_amount
+    FROM amazon_orders
     GROUP BY year_month, purchase_type
 ),
 
@@ -75,9 +85,9 @@ SELECT
      FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS recurring_spend,
     (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.category_spend ELSE 0 END)
      FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS oneoff_spend,
-    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.transaction_count ELSE 0 END)
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.order_count ELSE 0 END)
      FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS recurring_count,
-    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.transaction_count ELSE 0 END)
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.order_count ELSE 0 END)
      FROM purchase_type_split pt WHERE pt.year_month = bst.year_month) AS oneoff_count,
     (SELECT total_spend FROM period_stats ps WHERE ps.year_month = bst.year_month) AS total_monthly_spend
 FROM basket_size_trend bst

--- a/pipeline_personal_finance/dbt_finance/models/viz/groceries/viz_grocery_order_context.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/groceries/viz_grocery_order_context.sql
@@ -1,0 +1,96 @@
+{{ config(materialized='table') }}
+
+WITH grocery_transactions AS (
+    SELECT
+        ft.transaction_date,
+        CASE WHEN ft.transaction_amount < 0 THEN -ft.transaction_amount ELSE ft.transaction_amount END AS abs_amount,
+        ft.transaction_memo,
+        CASE
+            WHEN LOWER(ft.transaction_memo) LIKE '%coles%' THEN 'Coles'
+            WHEN LOWER(ft.transaction_memo) LIKE '%woolworths%' OR LOWER(ft.transaction_memo) LIKE '%woolies%' THEN 'Woolworths'
+            WHEN LOWER(ft.transaction_memo) LIKE '%gaskos%' OR LOWER(ft.transaction_memo) LIKE '%gascos%' THEN 'Gaskos'
+            ELSE 'Other'
+        END AS grocery_store,
+        -- Grocery subscription/recurring detection (e.g., home delivery subscriptions)
+        CASE
+            WHEN LOWER(ft.transaction_memo) LIKE '%subscription%'
+                OR LOWER(ft.transaction_memo) LIKE '%recurring%'
+                OR LOWER(ft.transaction_memo) LIKE '%delivery%'
+            THEN 'Subscription/Recurring'
+            ELSE 'One-Off Purchase'
+        END AS purchase_type,
+        DATE_TRUNC('month', ft.transaction_date) AS year_month
+    FROM {{ ref('fct_transactions') }} ft
+    WHERE
+        ft.transaction_amount < 0  -- Only expenses (negative amounts)
+        AND (
+            LOWER(ft.transaction_memo) LIKE '%coles%'
+            OR LOWER(ft.transaction_memo) LIKE '%woolworths%'
+            OR LOWER(ft.transaction_memo) LIKE '%woolies%'
+            OR LOWER(ft.transaction_memo) LIKE '%gaskos%'
+            OR LOWER(ft.transaction_memo) LIKE '%gascos%'
+        )
+),
+
+period_stats AS (
+    SELECT
+        year_month,
+        grocery_store,
+        COUNT(DISTINCT transaction_date) AS order_count,
+        ROUND(AVG(abs_amount), 2) AS average_order_value,
+        MAX(abs_amount) AS largest_order_value,
+        MIN(abs_amount) AS smallest_order_value,
+        SUM(abs_amount) AS total_spend
+    FROM grocery_transactions
+    GROUP BY year_month, grocery_store
+),
+
+purchase_type_split AS (
+    SELECT
+        year_month,
+        grocery_store,
+        purchase_type,
+        COUNT(*) AS transaction_count,
+        SUM(abs_amount) AS category_spend,
+        ROUND(AVG(abs_amount), 2) AS avg_amount
+    FROM grocery_transactions
+    GROUP BY year_month, grocery_store, purchase_type
+),
+
+basket_size_trend AS (
+    SELECT
+        year_month,
+        grocery_store,
+        order_count,
+        average_order_value,
+        LAG(average_order_value, 1) OVER (PARTITION BY grocery_store ORDER BY year_month) AS previous_month_aov,
+        CASE
+            WHEN LAG(average_order_value, 1) OVER (PARTITION BY grocery_store ORDER BY year_month) > 0 THEN
+                ROUND(((average_order_value - LAG(average_order_value, 1) OVER (PARTITION BY grocery_store ORDER BY year_month)) /
+                       LAG(average_order_value, 1) OVER (PARTITION BY grocery_store ORDER BY year_month)) * 100, 1)
+            ELSE NULL
+        END AS aov_mom_change_percent,
+        LAG(order_count, 12) OVER (PARTITION BY grocery_store ORDER BY year_month) AS same_month_last_year_orders
+    FROM period_stats
+)
+
+SELECT
+    bst.year_month,
+    bst.grocery_store,
+    bst.order_count,
+    bst.average_order_value,
+    (SELECT largest_order_value FROM period_stats ps WHERE ps.year_month = bst.year_month AND ps.grocery_store = bst.grocery_store) AS largest_order_value,
+    bst.previous_month_aov,
+    bst.aov_mom_change_percent,
+    bst.same_month_last_year_orders,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.category_spend ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month AND pt.grocery_store = bst.grocery_store) AS recurring_spend,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.category_spend ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month AND pt.grocery_store = bst.grocery_store) AS oneoff_spend,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'Subscription/Recurring' THEN pt.transaction_count ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month AND pt.grocery_store = bst.grocery_store) AS recurring_count,
+    (SELECT SUM(CASE WHEN pt.purchase_type = 'One-Off Purchase' THEN pt.transaction_count ELSE 0 END)
+     FROM purchase_type_split pt WHERE pt.year_month = bst.year_month AND pt.grocery_store = bst.grocery_store) AS oneoff_count,
+    (SELECT total_spend FROM period_stats ps WHERE ps.year_month = bst.year_month AND ps.grocery_store = bst.grocery_store) AS total_monthly_spend
+FROM basket_size_trend bst
+ORDER BY year_month DESC, grocery_store

--- a/pipeline_personal_finance/dbt_finance/models/viz/groceries/viz_grocery_order_context.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/groceries/viz_grocery_order_context.sql
@@ -33,6 +33,10 @@ WITH grocery_transactions AS (
 ),
 
 grocery_orders AS (
+    -- Group transactions by date and store as a proxy for orders
+    -- Note: This assumes one shopping trip per store per day. Multiple same-day trips to
+    -- the same store will be aggregated into a single order with combined amounts.
+    -- This is a limitation of not having explicit order IDs in the transaction data.
     SELECT
         transaction_date::date AS order_date,
         DATE_TRUNC('month', transaction_date) AS year_month,


### PR DESCRIPTION
## Summary
This PR adds order-level context and purchase type analysis to Amazon and Grocery spending dashboards. Users can now understand order patterns, identify spending drivers, and detect price inflation or volume changes.

## Changes
- **New SQL Models:**
  - `viz_amazon_order_context`: Analyzes Amazon transactions with order count, average order value, largest order, and subscription vs one-off split
  - `viz_grocery_order_context`: Analyzes grocery transactions by store (Coles, Woolworths, Gaskos) with identical metrics

- **Amazon Dashboard Updates:**
  - Added "Order Context (Latest Month)" stat panel showing order metrics
  - Added "Recurring vs One-Off (Latest Month)" stat panel showing purchase type breakdown
  - Added "Basket Size Trend" time series panel tracking average order value over 18 months

- **Grocery Dashboard Updates:**
  - Added "Order Context by Store (Latest Month)" stat panel with per-store metrics
  - Added "Recurring vs One-Off by Store (Latest Month)" stat panel with subscription analysis by retailer
  - Added "Basket Size Trend by Store" time series panel tracking trends per grocery store

## Feature Requirements Met
✓ Show order count, average order value, and largest order for the period
✓ Split recurring/subscription vs one-off purchases
✓ Add basket-size trend to spot price inflation or volume changes

## Testing
- SQL models use standard dbt patterns with ref() for proper lineage
- Queries in dashboard panels use the new visualization models via PostgreSQL datasource
- Models are materialized as tables for dashboard performance
- Window functions calculate month-over-month changes and year-over-year comparisons

🤖 Generated with Claude Code