### PR TITLE
fix: Populate banking_categories seed and handle missing current month

### DIFF
--- a/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
+++ b/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
@@ -1,1 +1,247 @@
-origin_key,transaction_description,transaction_type,sender,recipient,account_name,category,subcategory,store,internal_indicator
+transaction_description,transaction_type,sender,recipient,account_name,category,subcategory,store,internal_indicator
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,ING_Countdown,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,ING_Countdown,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,ING_Countdown,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,ING_Countdown,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,ING_Countdown,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,ING_Countdown,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,ING_Countdown,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,ING_Countdown,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,ING_Countdown,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,ING_Countdown,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,ING_Countdown,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,ING_Countdown,Transport,Public Transport,Transport,External
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,ING_BillsBillsBills,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,ING_BillsBillsBills,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,ING_BillsBillsBills,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,ING_BillsBillsBills,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,ING_BillsBillsBills,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,ING_BillsBillsBills,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,ING_BillsBillsBills,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,ING_BillsBillsBills,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,ING_BillsBillsBills,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,ING_BillsBillsBills,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,ING_BillsBillsBills,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,ING_BillsBillsBills,Transport,Public Transport,Transport,External
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,Adelaide_Offset,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,Adelaide_Offset,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,Adelaide_Offset,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,Adelaide_Offset,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,Adelaide_Offset,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,Adelaide_Offset,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,Adelaide_Offset,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,Adelaide_Offset,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,Adelaide_Offset,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,Adelaide_Offset,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,Adelaide_Offset,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,Adelaide_Offset,Transport,Public Transport,Transport,External
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,Adelaide_Homeloan,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,Adelaide_Homeloan,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,Adelaide_Homeloan,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,Adelaide_Homeloan,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,Adelaide_Homeloan,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,Adelaide_Homeloan,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,Adelaide_Homeloan,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,Adelaide_Homeloan,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,Adelaide_Homeloan,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,Adelaide_Homeloan,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,Adelaide_Homeloan,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,Adelaide_Homeloan,Transport,Public Transport,Transport,External
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,Bendigo_Offset,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,Bendigo_Offset,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,Bendigo_Offset,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,Bendigo_Offset,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,Bendigo_Offset,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,Bendigo_Offset,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,Bendigo_Offset,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,Bendigo_Offset,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,Bendigo_Offset,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,Bendigo_Offset,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,Bendigo_Offset,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,Bendigo_Offset,Transport,Public Transport,Transport,External
+PAYROLL,CREDIT,ACME_PAYROLL,YOU,Bendigo_Homeloan,Salary,Wages,Employer,External
+COLES,DEBIT,YOU,COLES,Bendigo_Homeloan,Food & Drink,Groceries,Coles,External
+UTIL,DEBIT,YOU,UTILITY_CO,Bendigo_Homeloan,Household & Services,Utilities,UtilityCo,External
+MORTGAGE PAYMENT,DEBIT,YOU,BANK_MORTGAGE,Bendigo_Homeloan,Mortgage,Home Loan,Mortgage,External
+INTEREST,INTEREST,BANK_MORTGAGE,YOU,Bendigo_Homeloan,Mortgage,Interest,Mortgage,External
+TRANSFER,DEBIT,YOU,TRANSFER,Bendigo_Homeloan,Bank Transaction,Internal Transfer,Internal,Internal
+AMAZON,DEBIT,YOU,AMAZON,Bendigo_Homeloan,Shopping,Online Retail,Amazon,External
+FAMILY,DEBIT,YOU,FAMILY_ACTIVITY,Bendigo_Homeloan,Family & Kids,Activities,Family,External
+HEALTH,DEBIT,YOU,HEALTH_SHOP,Bendigo_Homeloan,Health & Beauty,Pharmacy,Health,External
+LEISURE,DEBIT,YOU,LEISURE_OUTLET,Bendigo_Homeloan,Leisure,Entertainment,Leisure,External
+SHOPPING,DEBIT,YOU,SHOPPING_MALL,Bendigo_Homeloan,Shopping,Retail,Shopping,External
+TRANSPORT,DEBIT,YOU,TRANSPORT_CO,Bendigo_Homeloan,Transport,Public Transport,Transport,External
+mortgage,,,,adelaide_homeloan,Bank Transaction,Internal Transfer,mortgage,External
+mortgage,,,,adelaide_offset,Bank Transaction,Internal Transfer,mortgage,External
+mortgage,,,,bendigo_homeloan,Bank Transaction,Internal Transfer,mortgage,External
+mortgage,,,,bendigo_offset,Bank Transaction,Internal Transfer,mortgage,External
+mortgage,,,,ing_billsbillsbills,Bank Transaction,Internal Transfer,mortgage,External
+mortgage,,,,ing_countdown,Bank Transaction,Internal Transfer,mortgage,External
+offset,,,,adelaide_homeloan,Bank Transaction,Internal Transfer,offset,External
+offset,,,,adelaide_offset,Bank Transaction,Internal Transfer,offset,External
+offset,,,,bendigo_homeloan,Bank Transaction,Internal Transfer,offset,External
+offset,,,,bendigo_offset,Bank Transaction,Internal Transfer,offset,External
+offset,,,,ing_billsbillsbills,Bank Transaction,Internal Transfer,offset,External
+offset,,,,ing_countdown,Bank Transaction,Internal Transfer,offset,External
+Transfer to S Van Den Hoff,,,,adelaide_homeloan,Bank Transaction,Internal Transfer,Transfer,External
+Transfer to S Van Den Hoff,,,,adelaide_offset,Bank Transaction,Internal Transfer,Transfer,External
+Transfer to S Van Den Hoff,,,,bendigo_homeloan,Bank Transaction,Internal Transfer,Transfer,External
+Transfer to S Van Den Hoff,,,,bendigo_offset,Bank Transaction,Internal Transfer,Transfer,External
+Transfer to S Van Den Hoff,,,,ing_billsbillsbills,Bank Transaction,Internal Transfer,Transfer,External
+Transfer to S Van Den Hoff,,,,ing_countdown,Bank Transaction,Internal Transfer,Transfer,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,adelaide_homeloan,Salary,Wages,Achper,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,adelaide_offset,Salary,Wages,Achper,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,bendigo_homeloan,Salary,Wages,Achper,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,bendigo_offset,Salary,Wages,Achper,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,ing_billsbillsbills,Salary,Wages,Achper,External
+THE AUSTRALIAN C SP Pay from ACHPER,,,,ing_countdown,Salary,Wages,Achper,External
+save plus health insurance,,,,adelaide_homeloan,Bank Transaction,Internal Transfer,save,External
+save plus health insurance,,,,adelaide_offset,Bank Transaction,Internal Transfer,save,External
+save plus health insurance,,,,bendigo_homeloan,Bank Transaction,Internal Transfer,save,External
+save plus health insurance,,,,bendigo_offset,Bank Transaction,Internal Transfer,save,External
+save plus health insurance,,,,ing_billsbillsbills,Bank Transaction,Internal Transfer,save,External
+save plus health insurance,,,,ing_countdown,Bank Transaction,Internal Transfer,save,External
+MCARE BENEFITS   010190106 CYWQ,,,,adelaide_homeloan,Health & Beauty,Medicare Rebate,Medicare,External
+MCARE BENEFITS   010190106 CYWQ,,,,adelaide_offset,Health & Beauty,Medicare Rebate,Medicare,External
+MCARE BENEFITS   010190106 CYWQ,,,,bendigo_homeloan,Health & Beauty,Medicare Rebate,Medicare,External
+MCARE BENEFITS   010190106 CYWQ,,,,bendigo_offset,Health & Beauty,Medicare Rebate,Medicare,External
+MCARE BENEFITS   010190106 CYWQ,,,,ing_billsbillsbills,Health & Beauty,Medicare Rebate,Medicare,External
+MCARE BENEFITS   010190106 CYWQ,,,,ing_countdown,Health & Beauty,Medicare Rebate,Medicare,External
+A AND S WHOLESALE FR,,,,adelaide_homeloan,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+A AND S WHOLESALE FR,,,,adelaide_offset,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+A AND S WHOLESALE FR,,,,bendigo_homeloan,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+A AND S WHOLESALE FR,,,,bendigo_offset,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+A AND S WHOLESALE FR,,,,ing_billsbillsbills,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+A AND S WHOLESALE FR,,,,ing_countdown,Food & Drink,Groceries,MarketPlace Fresh Highpoint,External
+save for pps garage,,,,adelaide_homeloan,Bank Transaction,Internal Transfer,save,External
+save for pps garage,,,,adelaide_offset,Bank Transaction,Internal Transfer,save,External
+save for pps garage,,,,bendigo_homeloan,Bank Transaction,Internal Transfer,save,External
+save for pps garage,,,,bendigo_offset,Bank Transaction,Internal Transfer,save,External
+save for pps garage,,,,ing_billsbillsbills,Bank Transaction,Internal Transfer,save,External
+save for pps garage,,,,ing_countdown,Bank Transaction,Internal Transfer,save,External
+SQ *TP COFFEE HOUSE,,,,adelaide_homeloan,Food & Drink,Coffee,TP Coffee,External
+SQ *TP COFFEE HOUSE,,,,adelaide_offset,Food & Drink,Coffee,TP Coffee,External
+SQ *TP COFFEE HOUSE,,,,bendigo_homeloan,Food & Drink,Coffee,TP Coffee,External
+SQ *TP COFFEE HOUSE,,,,bendigo_offset,Food & Drink,Coffee,TP Coffee,External
+SQ *TP COFFEE HOUSE,,,,ing_billsbillsbills,Food & Drink,Coffee,TP Coffee,External
+SQ *TP COFFEE HOUSE,,,,ing_countdown,Food & Drink,Coffee,TP Coffee,External
+PUBLIC TRANSPORT VICT,,,,adelaide_homeloan,Transport,Public Transport,PTV,External
+PUBLIC TRANSPORT VICT,,,,adelaide_offset,Transport,Public Transport,PTV,External
+PUBLIC TRANSPORT VICT,,,,bendigo_homeloan,Transport,Public Transport,PTV,External
+PUBLIC TRANSPORT VICT,,,,bendigo_offset,Transport,Public Transport,PTV,External
+PUBLIC TRANSPORT VICT,,,,ing_billsbillsbills,Transport,Public Transport,PTV,External
+PUBLIC TRANSPORT VICT,,,,ing_countdown,Transport,Public Transport,PTV,External
+MCARE BENEFITS   020041372 CYWQ,,,,adelaide_homeloan,Health & Beauty,Medicare Rebate,MCARE,External
+MCARE BENEFITS   020041372 CYWQ,,,,adelaide_offset,Health & Beauty,Medicare Rebate,MCARE,External
+MCARE BENEFITS   020041372 CYWQ,,,,bendigo_homeloan,Health & Beauty,Medicare Rebate,MCARE,External
+MCARE BENEFITS   020041372 CYWQ,,,,bendigo_offset,Health & Beauty,Medicare Rebate,MCARE,External
+MCARE BENEFITS   020041372 CYWQ,,,,ing_billsbillsbills,Health & Beauty,Medicare Rebate,MCARE,External
+MCARE BENEFITS   020041372 CYWQ,,,,ing_countdown,Health & Beauty,Medicare Rebate,MCARE,External
+GOURMET DELI HOUSE,,,,adelaide_homeloan,Food & Drink,Groceries,GOURMET,External
+GOURMET DELI HOUSE,,,,adelaide_offset,Food & Drink,Groceries,GOURMET,External
+GOURMET DELI HOUSE,,,,bendigo_homeloan,Food & Drink,Groceries,GOURMET,External
+GOURMET DELI HOUSE,,,,bendigo_offset,Food & Drink,Groceries,GOURMET,External
+GOURMET DELI HOUSE,,,,ing_billsbillsbills,Food & Drink,Groceries,GOURMET,External
+GOURMET DELI HOUSE,,,,ing_countdown,Food & Drink,Groceries,GOURMET,External
+Reversal,,,,adelaide_homeloan,Bank Transaction,reversal,Reversal,External
+Reversal,,,,adelaide_offset,Bank Transaction,reversal,Reversal,External
+Reversal,,,,bendigo_homeloan,Bank Transaction,reversal,Reversal,External
+Reversal,,,,bendigo_offset,Bank Transaction,reversal,Reversal,External
+Reversal,,,,ing_billsbillsbills,Bank Transaction,reversal,Reversal,External
+Reversal,,,,ing_countdown,Bank Transaction,reversal,Reversal,External
+International Transaction Fee,,,,adelaide_homeloan,Bank Transaction,international trans fee,International,External
+International Transaction Fee,,,,adelaide_offset,Bank Transaction,international trans fee,International,External
+International Transaction Fee,,,,bendigo_homeloan,Bank Transaction,international trans fee,International,External
+International Transaction Fee,,,,bendigo_offset,Bank Transaction,international trans fee,International,External
+International Transaction Fee,,,,ing_billsbillsbills,Bank Transaction,international trans fee,International,External
+International Transaction Fee,,,,ing_countdown,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,adelaide_homeloan,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,adelaide_offset,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,bendigo_homeloan,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,bendigo_offset,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,ing_billsbillsbills,Bank Transaction,international trans fee,International,External
+International Transaction Fee Rebate,,,,ing_countdown,Bank Transaction,international trans fee,International,External
+KMART,,,,adelaide_homeloan,Shopping,Retail,KMART,External
+KMART,,,,adelaide_offset,Shopping,Retail,KMART,External
+KMART,,,,bendigo_homeloan,Shopping,Retail,KMART,External
+KMART,,,,bendigo_offset,Shopping,Retail,KMART,External
+KMART,,,,ing_billsbillsbills,Shopping,Retail,KMART,External
+KMART,,,,ing_countdown,Shopping,Retail,KMART,External
+THE WESTERN MEDICAL,,,,adelaide_homeloan,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL,,,,adelaide_offset,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL,,,,bendigo_homeloan,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL,,,,bendigo_offset,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL,,,,ing_billsbillsbills,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL,,,,ing_countdown,Health & Beauty,GP,Western Medical,External
+A.E.U. VICTORIAN,,,,adelaide_homeloan,Salary,Membership Fees,A.E.U.,External
+A.E.U. VICTORIAN,,,,adelaide_offset,Salary,Membership Fees,A.E.U.,External
+A.E.U. VICTORIAN,,,,bendigo_homeloan,Salary,Membership Fees,A.E.U.,External
+A.E.U. VICTORIAN,,,,bendigo_offset,Salary,Membership Fees,A.E.U.,External
+A.E.U. VICTORIAN,,,,ing_billsbillsbills,Salary,Membership Fees,A.E.U.,External
+A.E.U. VICTORIAN,,,,ing_countdown,Salary,Membership Fees,A.E.U.,External
+TIAN TRADINGS PTY LT,,,,adelaide_homeloan,Food & Drink,Groceries,TIAN,External
+TIAN TRADINGS PTY LT,,,,adelaide_offset,Food & Drink,Groceries,TIAN,External
+TIAN TRADINGS PTY LT,,,,bendigo_homeloan,Food & Drink,Groceries,TIAN,External
+TIAN TRADINGS PTY LT,,,,bendigo_offset,Food & Drink,Groceries,TIAN,External
+TIAN TRADINGS PTY LT,,,,ing_billsbillsbills,Food & Drink,Groceries,TIAN,External
+TIAN TRADINGS PTY LT,,,,ing_countdown,Food & Drink,Groceries,TIAN,External
+The Other Brother,,,,adelaide_homeloan,Food & Drink,Coffee,Other Brother,External
+The Other Brother,,,,adelaide_offset,Food & Drink,Coffee,Other Brother,External
+The Other Brother,,,,bendigo_homeloan,Food & Drink,Coffee,Other Brother,External
+The Other Brother,,,,bendigo_offset,Food & Drink,Coffee,Other Brother,External
+The Other Brother,,,,ing_billsbillsbills,Food & Drink,Coffee,Other Brother,External
+The Other Brother,,,,ing_countdown,Food & Drink,Coffee,Other Brother,External
+MARKETPLACE FRESH,,,,adelaide_homeloan,Food & Drink,Groceries,MARKETPLACE,External
+MARKETPLACE FRESH,,,,adelaide_offset,Food & Drink,Groceries,MARKETPLACE,External
+MARKETPLACE FRESH,,,,bendigo_homeloan,Food & Drink,Groceries,MARKETPLACE,External
+MARKETPLACE FRESH,,,,bendigo_offset,Food & Drink,Groceries,MARKETPLACE,External
+MARKETPLACE FRESH,,,,ing_billsbillsbills,Food & Drink,Groceries,MARKETPLACE,External
+MARKETPLACE FRESH,,,,ing_countdown,Food & Drink,Groceries,MARKETPLACE,External
+PRIMUS TELECOMS,,,,adelaide_homeloan,Household & Services,Utilities,iPrimus,External
+PRIMUS TELECOMS,,,,adelaide_offset,Household & Services,Utilities,iPrimus,External
+PRIMUS TELECOMS,,,,bendigo_homeloan,Household & Services,Utilities,iPrimus,External
+PRIMUS TELECOMS,,,,bendigo_offset,Household & Services,Utilities,iPrimus,External
+PRIMUS TELECOMS,,,,ing_billsbillsbills,Household & Services,Utilities,iPrimus,External
+PRIMUS TELECOMS,,,,ing_countdown,Household & Services,Utilities,iPrimus,External
+APPLE.COM/BILL,,,,adelaide_homeloan,Household & Services,mobile,APPLE.COM/BILL,External
+APPLE.COM/BILL,,,,adelaide_offset,Household & Services,mobile,APPLE.COM/BILL,External
+APPLE.COM/BILL,,,,bendigo_homeloan,Household & Services,mobile,APPLE.COM/BILL,External
+APPLE.COM/BILL,,,,bendigo_offset,Household & Services,mobile,APPLE.COM/BILL,External
+APPLE.COM/BILL,,,,ing_billsbillsbills,Household & Services,mobile,APPLE.COM/BILL,External
+APPLE.COM/BILL,,,,ing_countdown,Household & Services,mobile,APPLE.COM/BILL,External
+YMCA CP FOOTSCRAY,,,,adelaide_homeloan,Household & Services,Gym,YMCA,External
+YMCA CP FOOTSCRAY,,,,adelaide_offset,Household & Services,Gym,YMCA,External
+YMCA CP FOOTSCRAY,,,,bendigo_homeloan,Household & Services,Gym,YMCA,External
+YMCA CP FOOTSCRAY,,,,bendigo_offset,Household & Services,Gym,YMCA,External
+YMCA CP FOOTSCRAY,,,,ing_billsbillsbills,Household & Services,Gym,YMCA,External
+YMCA CP FOOTSCRAY,,,,ing_countdown,Household & Services,Gym,YMCA,External
+Telstra Services,,,,adelaide_homeloan,Household & Services,Mobile,Telstra,External
+Telstra Services,,,,adelaide_offset,Household & Services,Mobile,Telstra,External
+Telstra Services,,,,bendigo_homeloan,Household & Services,Mobile,Telstra,External
+Telstra Services,,,,bendigo_offset,Household & Services,Mobile,Telstra,External
+Telstra Services,,,,ing_billsbillsbills,Household & Services,Mobile,Telstra,External
+Telstra Services,,,,ing_countdown,Household & Services,Mobile,Telstra,External
+THE WESTERN MEDICAL CE,,,,adelaide_homeloan,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL CE,,,,adelaide_offset,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL CE,,,,bendigo_homeloan,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL CE,,,,bendigo_offset,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL CE,,,,ing_billsbillsbills,Health & Beauty,GP,Western Medical,External
+THE WESTERN MEDICAL CE,,,,ing_countdown,Health & Beauty,GP,Western Medical,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,adelaide_homeloan,Salary,Wages,PARENTALLEAVEPAY,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,adelaide_offset,Salary,Wages,PARENTALLEAVEPAY,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,bendigo_homeloan,Salary,Wages,PARENTALLEAVEPAY,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,bendigo_offset,Salary,Wages,PARENTALLEAVEPAY,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,ing_billsbillsbills,Salary,Wages,PARENTALLEAVEPAY,External
+PARENTALLEAVEPAY TP1J1155304023246L,,,,ing_countdown,Salary,Wages,PARENTALLEAVEPAY,External
+RAINBOW MEATS,,,,adelaide_homeloan,Food & Drink,Groceries,RAINBOW,External
+RAINBOW MEATS,,,,adelaide_offset,Food & Drink,Groceries,RAINBOW,External
+RAINBOW MEATS,,,,bendigo_homeloan,Food & Drink,Groceries,RAINBOW,External
+RAINBOW MEATS,,,,bendigo_offset,Food & Drink,Groceries,RAINBOW,External
+RAINBOW MEATS,,,,ing_billsbillsbills,Food & Drink,Groceries,RAINBOW,External
+RAINBOW MEATS,,,,ing_countdown,Food & Drink,Groceries,RAINBOW,External
+534 BARKLY ST DTL P/L,,,,adelaide_homeloan,Health & Beauty,Dentist,534 BARKLY ST,External
+534 BARKLY ST DTL P/L,,,,adelaide_offset,Health & Beauty,Dentist,534 BARKLY ST,External
+534 BARKLY ST DTL P/L,,,,bendigo_homeloan,Health & Beauty,Dentist,534 BARKLY ST,External
+534 BARKLY ST DTL P/L,,,,bendigo_offset,Health & Beauty,Dentist,534 BARKLY ST,External
+534 BARKLY ST DTL P/L,,,,ing_billsbillsbills,Health & Beauty,Dentist,534 BARKLY ST,External
+534 BARKLY ST DTL P/L,,,,ing_countdown,Health & Beauty,Dentist,534 BARKLY ST,External


### PR DESCRIPTION
## Summary
Fixes the "No data" errors in the new Family Essentials and Week-to-Date Spending Pace panels added in PR #31.

## Root Causes Found
1. **Empty banking_categories seed** - The `seeds/banking_categories.csv` file was empty (only header), causing `dim_categories` to only contain "Uncategorized"
2. **Missing current month data** - `rpt_weekly_spending_pace` queried for 2026-02 budget data, but only data through 2025-12 exists

## Changes

### Seed Data
- Copied 246 transaction category mappings from `seeds/local/banking_categories.csv` to `seeds/banking_categories.csv`
- This enables proper categorization of transactions into Food & Drink, Family & Kids, Health & Beauty, etc.

### Weekly Pace Model
- Updated `rpt_weekly_spending_pace.sql` to fallback to the latest available month when current month has no budget data
- Added `latest_available_month` CTE to find MAX(budget_year_month) from rpt_monthly_budget_summary
- Uses COALESCE to prefer current month, fallback to latest available

## Database Verification
Before fix:
- `dim_categories`: 1 row (only Uncategorized)
- `rpt_family_essentials`: 0 rows
- `rpt_weekly_spending_pace`: 0 rows

After fix (once dbt models are rebuilt):
- `dim_categories`: Will have all category mappings
- `rpt_family_essentials`: Will show monthly spending across 4 essential categories
- `rpt_weekly_spending_pace`: Will calculate weekly budget tracking

## Required Steps

After merging, run these commands in order:

```bash
# 1. Re-seed banking_categories
dbt seed --select banking_categories

# 2. Rebuild dimensions
dbt run --select dim_categories

# 3. Rebuild reporting models
dbt run --select rpt_family_essentials rpt_emergency_fund_coverage rpt_weekly_spending_pace
```

Then refresh the Grafana Executive dashboard to see populated panels.

## Related
- Fixes issues discovered in PR #31 during dashboard verification
- Screenshot: `screenshots/executive-dashboard-new-panels.png` shows "No data" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)