### PR TITLE
Use latest loaded month for budget reports

### DIFF
--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
@@ -67,10 +67,11 @@ monthly_totals AS (
   GROUP BY budget_year_month, transaction_year, transaction_month
 ),
 
--- Anchor to the freshest fully-loaded month so the executive panel never returns zero rows
+-- Anchor to the freshest fully-loaded month (exclude the in-progress calendar month)
 latest_month AS (
   SELECT MAX(to_date(budget_year_month || '-01', 'YYYY-MM-DD')) AS max_month
   FROM monthly_totals
+  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') < date_trunc('month', CURRENT_DATE)
 ),
 
 with_trends AS (


### PR DESCRIPTION
## Summary
- select latest fully-loaded month for family essentials report
- anchor emergency fund report to latest available month

## Testing
- not run (data/warehouse query only)