### PR TITLE
feat: Complete Executive Dashboard fixes (Tasks 21-30)

### DIFF
--- a/activity.md
+++ b/activity.md
@@ -332,3 +332,9 @@ This file logs what the agent accomplishes during each iteration:
 **Commit**: `6a4646c` - "feat: Complete dashboard fixes for tasks 21-30"
 
 **Plan Status**: Tasks 21-30 marked as completed in plan.md
+
+**Critical Fixes**: `be68f4b` - "fix: Correct waterfall unique index and liability classification"
+- **P1 Fix 1**: Changed waterfall model unique index from single column `budget_year_month` to composite `(budget_year_month, driver)` - model emits 4 rows per month so single column would cause unique constraint violation on dbt run
+- **P1 Fix 2**: Changed liability classification from `account_type = 'liability'` to `is_liability` flag - account_type contains values like 'Home Loan', 'Offset', not the string 'liability'; without this fix all liabilities would be misclassified as assets, making total_liabilities = 0 and inflating net_worth
+
+**PR Created**: https://github.com/Crow2525-pp/qif_personal_finance/pull/35

--- a/activity.md
+++ b/activity.md
@@ -278,3 +278,57 @@ This file logs what the agent accomplishes during each iteration:
 **PR Created**: https://github.com/Crow2525-pp/qif_personal_finance/pull/25
 
 **Plan Status**: Updated plan.md to mark task as passes: true
+
+## 2026-02-02
+
+### Executive Dashboard Fixes (Tasks 21-30)
+
+**Task**: Complete all 10 dashboard fix tasks from plan.md (tasks 21-30) to improve data accuracy, visualization clarity, and actionability.
+
+**Status**: COMPLETED - Branch `feature/dashboard-fixes-tasks-21-30` created
+
+**Actions performed**:
+
+1. **Stat Panel Fixes (Tasks 21, 23, 28, 29)**:
+   - Task 21: Fixed Family Essentials stat with COALESCE on all spend columns; updated Grafana to set `reduceOptions.values=true` and show only Total Essentials field
+   - Task 23: Restored Monthly Financial Snapshot by sourcing from `rpt_cash_flow_analysis` instead of `rpt_monthly_budget_summary`; corrected field mappings to use `total_inflows`/`total_outflows`
+   - Task 28: Improved Week-to-Date Spending Pace by adding `pace_ratio` (wtd_spending / expected_spend_to_date * 100) and `expected_spend_to_date` field; updated Grafana stat with percent unit and color-coded thresholds (<90 green, 90-110 yellow, >110 red)
+   - Task 29: Tightened Emergency Fund Coverage gauge calculation using NULLIF for safe division; updated Grafana gauge to max 6 months (was 12) with proper month unit
+
+2. **Chart Visualizations (Tasks 22, 24, 25)**:
+   - Task 22: Corrected Asset & Liability Snapshot sign logic using ABS(end_of_month_balance) for all calculations; changed to `account_type != 'liability'` for assets and `account_type = 'liability'` for liabilities; fixed net_worth = total_assets - total_liabilities with proper NULLIF handling
+   - Task 24: Fixed Savings & Expense Performance to return 0-100 percent values (`savings_rate_pct`, `savings_rate_3m_pct`, `savings_rate_ytd_pct`, `expense_ratio_pct`) instead of ratios; updated Grafana bar gauge from `percentunit` to `percent` with thresholds at 5/10/20/30 and min 0 max 100
+   - Task 25: Aligned Cash Flow Trend forecast to display one month ahead by adding `+ interval '1 month'` to forecast dates; split query into separate result sets for historical vs forecast data; updated visualization with bars for Net Cash Flow, line for 3-Month Avg, and dashed line with light fill for Forecast
+
+3. **Table Panel Improvements (Tasks 26, 27)**:
+   - Task 26: Made Data Quality Callouts numeric and actionable by returning `uncategorized_pct` as numeric value (no % string) and exposing `uncategorized_amount`; updated Grafana table with percent unit, thresholds (green <10, yellow 10-15, red >15), cell background coloring, and link to `/d/transaction_analysis_dashboard?var_category=Uncategorized`
+   - Task 27: Added actionability to Top Uncategorized Merchants by calculating `contribution_pct` (total_amount / sum of all uncategorized * 100); added filtering WHERE txn_count>=2 OR total_amount>=100 to focus on patterns; updated Grafana table with Contribution % column (percent unit, 2 decimals) and URL link per merchant to categorization workflow
+
+4. **Waterfall Visualization (Task 30)**:
+   - Created new dbt model `rpt_mom_cash_flow_waterfall.sql` to calculate month-over-month deltas:
+     - income_delta = curr.total_income - prev.total_income
+     - expense_delta = -(curr.total_expenses - prev.total_expenses) [negated so decreases show as positive]
+     - transfers_delta = curr.internal_transfers - prev.internal_transfers
+     - net_delta = curr.net_cash_flow - prev.net_cash_flow
+   - Unpivots deltas into 4 rows per month: Income, Expenses, Transfers, Net Change with sort_order for proper display
+   - Replaced "Month-over-Month Cash Changes" table panel with horizontal bar chart waterfall visualization
+   - Color thresholds: Red for negative (<0), Green for positive (>=0), Blue for Net Change
+   - Added schema documentation to schema.yml
+
+**Files Modified**:
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_emergency_fund_coverage.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_household_net_worth.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_monthly_budget_summary.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_outflows_insights_dashboard.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_weekly_spending_pace.sql`
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/schema.yml`
+- `pipeline_personal_finance/dbt_finance/models/viz/expenses/viz_uncategorized_transactions_with_original_memo.sql`
+- `grafana/provisioning/dashboards/executive-dashboard.json`
+
+**Files Created**:
+- `pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_mom_cash_flow_waterfall.sql`
+
+**Commit**: `6a4646c` - "feat: Complete dashboard fixes for tasks 21-30"
+
+**Plan Status**: Tasks 21-30 marked as completed in plan.md

--- a/grafana/provisioning/dashboards/executive-dashboard.json
+++ b/grafana/provisioning/dashboards/executive-dashboard.json
@@ -145,7 +145,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncurrent_budget AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_cf AS (\n  SELECT forecasted_next_month_net_flow\n  FROM reporting.rpt_cash_flow_analysis\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_scores AS (\n  SELECT\n    CASE\n      WHEN cb.savings_rate_percent >= 0.30 THEN 'Excellent'\n      WHEN cb.savings_rate_percent >= 0.20 THEN 'Strong'\n      WHEN cb.savings_rate_percent >= 0.15 THEN 'Good'\n      WHEN cb.savings_rate_percent >= 0.10 THEN 'Fair'\n      ELSE 'Needs Attention'\n    END AS savings_rating\n  FROM current_budget cb\n),\nsummary AS (\n  SELECT\n    to_char((SELECT month_date FROM selected_period), 'Mon YYYY') AS month_label,\n    CASE\n      WHEN cb.net_cash_flow >= 0 THEN 'Positive'\n      ELSE 'Negative'\n    END AS health_rating,\n    COALESCE(ccf.forecasted_next_month_net_flow, 0) AS forecast_value\n  FROM current_budget cb\n  LEFT JOIN current_cf ccf ON TRUE\n)\nSELECT CONCAT('\ud83d\udcca Financial Summary for ', summary.month_label,\n              ' | Net Cash Flow: ', summary.health_rating,\n              ' | Next Month Forecast: $', ROUND(summary.forecast_value)::text) AS summary\nFROM summary;",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncurrent_budget AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_cf AS (\n  SELECT forecasted_next_month_net_flow\n  FROM reporting.rpt_cash_flow_analysis\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_scores AS (\n  SELECT\n    CASE\n      WHEN cb.savings_rate_percent >= 0.30 THEN 'Excellent'\n      WHEN cb.savings_rate_percent >= 0.20 THEN 'Strong'\n      WHEN cb.savings_rate_percent >= 0.15 THEN 'Good'\n      WHEN cb.savings_rate_percent >= 0.10 THEN 'Fair'\n      ELSE 'Needs Attention'\n    END AS savings_rating\n  FROM current_budget cb\n),\nsummary AS (\n  SELECT\n    to_char((SELECT month_date FROM selected_period), 'Mon YYYY') AS month_label,\n    CASE\n      WHEN cb.net_cash_flow >= 0 THEN 'Positive'\n      ELSE 'Negative'\n    END AS health_rating,\n    COALESCE(ccf.forecasted_next_month_net_flow, 0) AS forecast_value\n  FROM current_budget cb\n  LEFT JOIN current_cf ccf ON TRUE\n)\nSELECT CONCAT('📊 Financial Summary for ', summary.month_label,\n              ' | Net Cash Flow: ', summary.health_rating,\n              ' | Next Month Forecast: $', ROUND(summary.forecast_value)::text) AS summary\nFROM summary;",
           "refId": "A"
         }
       ],
@@ -157,7 +157,7 @@
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
       },
-      "description": "Overall financial health scoreboard. Each bar reflects raw ratios from the selected month: savings performance is net cash flow \u00f7 income, cash-flow status comes from the cash-flow analysis state machine, and net-worth progress tracks the wealth milestone. The composite score weights net worth 30%, savings 30%, and cash flow 40%.",
+      "description": "Overall financial health scoreboard. Each bar reflects raw ratios from the selected month: savings performance is net cash flow ÷ income, cash-flow status comes from the cash-flow analysis state machine, and net-worth progress tracks the wealth milestone. The composite score weights net worth 30%, savings 30%, and cash flow 40%.",
       "fieldConfig": {
         "defaults": {
           "min": 0,
@@ -386,7 +386,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "\u0394 ($)"
+                "value": "Δ ($)"
               },
               {
                 "id": "unit",
@@ -402,7 +402,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "\u0394 Ratio"
+                "value": "Δ Ratio"
               },
               {
                 "id": "unit",
@@ -425,14 +425,14 @@
           "refId": "A"
         }
       ],
-      "description": "Cash-oriented KPIs with raw values; \u0394 Ratio shows change vs the previous month."
+      "description": "Cash-oriented KPIs with raw values; Δ Ratio shows change vs the previous month."
     },
     {
       "datasource": {
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
       },
-      "description": "Savings and expense ratios for the selected month. Savings rate values are raw ratios (0\u20131) of net cash flow to income across the monthly, 3\u2011month rolling, and year\u2011to\u2011date views. Expense ratio is total outflows divided by inflows; lower numbers signal tighter expense control.",
+      "description": "Savings and expense ratios for the selected month. Savings rate values are raw ratios (0–1) of net cash flow to income across the monthly, 3‑month rolling, and year‑to‑date views. Expense ratio is total outflows divided by inflows; lower numbers signal tighter expense control.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -447,8 +447,6 @@
             "width": 0.6
           },
           "mappings": [],
-          "max": 1,
-          "min": -1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -458,19 +456,25 @@
               },
               {
                 "color": "#CD853F",
-                "value": 0.1
+                "value": 5
               },
               {
                 "color": "#DAA520",
-                "value": 0.2
+                "value": 10
+              },
+              {
+                "color": "#FFD700",
+                "value": 20
               },
               {
                 "color": "#32CD32",
-                "value": 0.3
+                "value": 30
               }
             ]
           },
-          "unit": "percentunit",
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
           "links": [
             {
               "title": "View Savings Analysis Details",
@@ -547,14 +551,6 @@
                   "fixedColor": "#66BB6A",
                   "mode": "fixed"
                 }
-              },
-              {
-                "id": "max",
-                "value": 1.5
-              },
-              {
-                "id": "min",
-                "value": 0
               }
             ]
           }
@@ -589,7 +585,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\nrolling AS (\n  SELECT to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date,\n         savings_rate_percent,\n         AVG(savings_rate_percent) OVER (ORDER BY to_date(budget_year_month || '-01', 'YYYY-MM-DD') ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS savings_rate_3m\n  FROM reporting.rpt_monthly_budget_summary\n),\ncurrent_budget AS (\n  SELECT *\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_roll AS (\n  SELECT *\n  FROM rolling\n  WHERE month_date = (SELECT month_date FROM selected_period)\n),\ncurrent_cf AS (\n  SELECT *\n  FROM reporting.rpt_cash_flow_analysis\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n)\nSELECT 'Savings Rate (Monthly)' AS metric_label, current_budget.savings_rate_percent AS value FROM current_budget\nUNION ALL\nSELECT 'Savings Rate (3M Avg)', COALESCE(current_roll.savings_rate_3m, current_budget.savings_rate_percent) FROM current_budget LEFT JOIN current_roll ON TRUE\nUNION ALL\nSELECT 'Savings Rate (YTD)', CASE WHEN current_budget.ytd_income = 0 THEN 0 ELSE current_budget.ytd_net_cash_flow / current_budget.ytd_income END FROM current_budget\nUNION ALL\nSELECT 'Expense Ratio (%)', current_cf.outflow_to_inflow_ratio FROM current_cf;",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncurrent_budget AS (\n  SELECT *\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n)\nSELECT 'Savings Rate (Monthly)' AS metric_label, current_budget.savings_rate_pct AS value FROM current_budget\nUNION ALL\nSELECT 'Savings Rate (3M Avg)', COALESCE(current_budget.savings_rate_3m_pct, current_budget.savings_rate_pct) FROM current_budget\nUNION ALL\nSELECT 'Savings Rate (YTD)', current_budget.savings_rate_ytd_pct FROM current_budget\nUNION ALL\nSELECT 'Expense Ratio (%)', current_budget.expense_ratio_pct FROM current_budget;",
           "refId": "A"
         }
       ],
@@ -719,7 +715,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "\u0394"
+                "value": "Δ"
               },
               {
                 "id": "unit",
@@ -735,7 +731,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "\u0394 Ratio"
+                "value": "Δ Ratio"
               },
               {
                 "id": "unit",
@@ -745,14 +741,14 @@
           }
         ]
       },
-      "description": "Score and risk KPIs expressed as raw values; \u0394 Ratio captures relative change where applicable."
+      "description": "Score and risk KPIs expressed as raw values; Δ Ratio captures relative change where applicable."
     },
     {
       "datasource": {
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
       },
-      "description": "Expense Control Score translates your outflow-to-inflow ratio into a 0-100 scale. Scores above 80 mean expenses are \u226490% of income (strong control). 55\u201370 means you\u2019re spending roughly 100\u2013110% of income (monitor closely). A 10 indicates expenses exceed 150% of income\u2014an immediate signal that cash burn is unsustainable.",
+      "description": "Expense Control Score translates your outflow-to-inflow ratio into a 0-100 scale. Scores above 80 mean expenses are ≤90% of income (strong control). 55–70 means you’re spending roughly 100–110% of income (monitor closely). A 10 indicates expenses exceed 150% of income—an immediate signal that cash burn is unsustainable.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1089,7 +1085,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncurrent_budget AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_nw AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_household_net_worth\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n)\nSELECT\n  ROUND(cb.total_income, 2) AS monthly_income,\n  ROUND(cb.total_expenses, 2) AS monthly_expenses,\n  ROUND(cb.net_cash_flow, 2) AS monthly_net_cash_flow,\n  ROUND(cb.total_income - cb.total_expenses, 2) AS monthly_total_savings,\n  ROUND(cnw.net_worth, 2) AS current_net_worth,\n  ROUND(cnw.liquid_assets, 2) AS liquid_assets\nFROM current_budget cb\nLEFT JOIN current_nw cnw ON TRUE;",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_cash_flow_analysis\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\ncurrent_cash_flow AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_cash_flow_analysis\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\ncurrent_nw AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_household_net_worth\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n)\nSELECT\n  ROUND(COALESCE(cf.total_inflows, 0), 2) AS monthly_income,\n  ROUND(COALESCE(cf.total_outflows, 0), 2) AS monthly_expenses,\n  ROUND(COALESCE(cf.net_cash_flow, 0), 2) AS monthly_net_cash_flow,\n  ROUND(COALESCE(cf.net_cash_flow, 0), 2) AS monthly_total_savings,\n  ROUND(COALESCE(cnw.net_worth, 0), 2) AS current_net_worth,\n  ROUND(COALESCE(cnw.liquid_assets, 0), 2) AS liquid_assets\nFROM current_cash_flow cf\nLEFT JOIN current_nw cnw ON TRUE;",
           "refId": "A"
         }
       ],
@@ -1158,6 +1154,18 @@
                   "fixedColor": "#32CD32",
                   "mode": "fixed"
                 }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 80
               }
             ]
           },
@@ -1173,6 +1181,14 @@
                   "fixedColor": "#4169E1",
                   "mode": "fixed"
                 }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
               }
             ]
           },
@@ -1188,6 +1204,25 @@
                   "fixedColor": "#FF6347",
                   "mode": "fixed"
                 }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [10, 10],
+                  "fill": "dash"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 10
               }
             ]
           }
@@ -1220,7 +1255,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncash_history AS (\n  SELECT to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date,\n         net_cash_flow\n  FROM reporting.rpt_monthly_budget_summary\n),\ncash_with_avg AS (\n  SELECT month_date,\n         net_cash_flow,\n         AVG(net_cash_flow) OVER (ORDER BY month_date ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg_3m\n  FROM cash_history\n),\nforecast_history AS (\n  SELECT to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date,\n         forecasted_next_month_net_flow\n  FROM reporting.rpt_cash_flow_analysis\n),\nwindowed AS (\n  SELECT c.month_date,\n         c.net_cash_flow,\n         c.avg_3m,\n         f.forecasted_next_month_net_flow,\n         ROW_NUMBER() OVER (ORDER BY c.month_date DESC) AS rn\n  FROM cash_with_avg c\n  LEFT JOIN forecast_history f ON f.month_date = c.month_date\n  WHERE c.month_date <= (SELECT month_date FROM selected_period)\n)\nSELECT month_date AS \"time\",\n       net_cash_flow AS \"Net Cash Flow\",\n       avg_3m AS \"3-Month Avg\",\n       forecasted_next_month_net_flow AS \"Forecast Next Month\"\nFROM windowed\nWHERE rn <= 12\nORDER BY month_date;",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncash_history AS (\n  SELECT to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date,\n         net_cash_flow\n  FROM reporting.rpt_monthly_budget_summary\n),\ncash_with_avg AS (\n  SELECT month_date,\n         net_cash_flow,\n         AVG(net_cash_flow) OVER (ORDER BY month_date ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS avg_3m\n  FROM cash_history\n),\nforecast_history AS (\n  SELECT to_date(budget_year_month || '-01', 'YYYY-MM-DD') + interval '1 month' AS forecast_date,\n         forecasted_next_month_net_flow\n  FROM reporting.rpt_cash_flow_analysis\n),\nwindowed AS (\n  SELECT c.month_date,\n         c.net_cash_flow,\n         c.avg_3m,\n         ROW_NUMBER() OVER (ORDER BY c.month_date DESC) AS rn\n  FROM cash_with_avg c\n  WHERE c.month_date <= (SELECT month_date FROM selected_period)\n),\nforecast_windowed AS (\n  SELECT f.forecast_date,\n         f.forecasted_next_month_net_flow,\n         ROW_NUMBER() OVER (ORDER BY f.forecast_date DESC) AS rn\n  FROM forecast_history f\n  WHERE f.forecast_date <= (SELECT month_date FROM selected_period) + interval '1 month'\n)\nSELECT month_date AS \"time\",\n       net_cash_flow AS \"Net Cash Flow\",\n       avg_3m AS \"3-Month Avg\",\n       NULL::numeric AS \"Forecast Next Month\"\nFROM windowed\nWHERE rn <= 12\nUNION ALL\nSELECT forecast_date AS \"time\",\n       NULL::numeric AS \"Net Cash Flow\",\n       NULL::numeric AS \"3-Month Avg\",\n       forecasted_next_month_net_flow AS \"Forecast Next Month\"\nFROM forecast_windowed\nWHERE rn <= 12\nORDER BY \"time\";",
           "refId": "A"
         }
       ],
@@ -1429,8 +1464,8 @@
     },
     {
       "id": 13,
-      "title": "Month-over-Month Cash Changes",
-      "type": "table",
+      "title": "Cash Flow Drivers (Month-over-Month)",
+      "type": "barchart",
       "datasource": {
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
@@ -1442,92 +1477,137 @@
         "h": 6
       },
       "options": {
-        "cellHeight": "sm",
-        "showHeader": true
+        "orientation": "horizontal",
+        "xField": "driver",
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        },
+        "barWidth": 0.6,
+        "groupWidth": 0.7,
+        "showValue": "never",
+        "stacking": "none"
       },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "red"
+              },
+              {
+                "value": 0,
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "currencyUSD",
           "custom": {
-            "align": "left"
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "axisPlacement": "auto"
           }
         },
         "overrides": [
           {
             "matcher": {
               "id": "byName",
-              "options": "current_value"
+              "options": "driver"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "Current ($)"
+                "value": "Driver"
               },
               {
-                "id": "unit",
-                "value": "currencyUSD"
+                "id": "custom.axisPlacement",
+                "value": "left"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "previous_value"
+              "options": "delta_amount"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "Previous ($)"
+                "value": "Change ($)"
               },
               {
-                "id": "unit",
-                "value": "currencyUSD"
+                "id": "custom.axisPlacement",
+                "value": "bottom"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "delta_value"
+              "options": "current_income"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "\u0394 ($)"
-              },
-              {
-                "id": "unit",
-                "value": "currencyUSD"
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": true,
+                  "legend": true
+                }
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "delta_ratio"
+              "options": "previous_income"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "\u0394 Ratio"
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": true,
+                  "legend": true
+                }
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "metric"
+              "options": "Net Change"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "Metric"
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "value": null,
+                      "color": "red"
+                    },
+                    {
+                      "value": 0,
+                      "color": "blue"
+                    }
+                  ]
+                }
               }
             ]
           }
@@ -1542,11 +1622,11 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nprevious_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n  WHERE month_date < (SELECT month_date FROM selected_period)\n),\ncurrent_budget AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\nprevious_budget AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM previous_period)\n),\ncurrent_nw AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_household_net_worth\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM selected_period)\n),\nprevious_nw AS (\n  SELECT *, to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_household_net_worth\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD') = (SELECT month_date FROM previous_period)\n)\nSELECT 'Net Cash Flow' AS metric,\n       cb.net_cash_flow AS current_value,\n       COALESCE(pb.net_cash_flow, cb.net_cash_flow) AS previous_value,\n       cb.net_cash_flow - COALESCE(pb.net_cash_flow, 0) AS delta_value,\n       CASE WHEN COALESCE(pb.net_cash_flow, 0) = 0 THEN NULL\n            ELSE (cb.net_cash_flow - COALESCE(pb.net_cash_flow, 0)) / NULLIF(ABS(pb.net_cash_flow), 0)\n       END AS delta_ratio\nFROM current_budget cb LEFT JOIN previous_budget pb ON TRUE\nUNION ALL\nSELECT 'Net Worth',\n       cnw.net_worth,\n       COALESCE(pnw.net_worth, cnw.net_worth),\n       cnw.net_worth - COALESCE(pnw.net_worth, 0),\n       CASE WHEN COALESCE(pnw.net_worth, 0) = 0 THEN NULL\n            ELSE (cnw.net_worth - COALESCE(pnw.net_worth, 0)) / NULLIF(ABS(pnw.net_worth), 0)\n       END\nFROM current_nw cnw LEFT JOIN previous_nw pnw ON TRUE\nUNION ALL\nSELECT 'Liquid Assets',\n       cnw.liquid_assets,\n       COALESCE(pnw.liquid_assets, cnw.liquid_assets),\n       cnw.liquid_assets - COALESCE(pnw.liquid_assets, 0),\n       CASE WHEN COALESCE(pnw.liquid_assets, 0) = 0 THEN NULL\n            ELSE (cnw.liquid_assets - COALESCE(pnw.liquid_assets, 0)) / NULLIF(ABS(pnw.liquid_assets), 0)\n       END\nFROM current_nw cnw LEFT JOIN previous_nw pnw ON TRUE;",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nselected_key AS (\n  SELECT to_char(month_date, 'YYYY-MM') AS month_key\n  FROM selected_period\n)\nSELECT\n  driver,\n  delta_amount,\n  current_income,\n  previous_income\nFROM reporting.rpt_mom_cash_flow_waterfall\nWHERE budget_year_month = (SELECT month_key FROM selected_key)\nORDER BY sort_order;",
           "refId": "A"
         }
       ],
-      "description": "Cash-based month-over-month changes for the selected period. \u0394 Ratio shows the percent change relative to the previous month when available."
+      "description": "Waterfall showing what drove the month-over-month change in net cash flow: income changes, expense changes, and internal transfers."
     },
     {
       "id": 101,
@@ -1641,7 +1721,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "\u0394"
+                "value": "Δ"
               },
               {
                 "id": "unit",
@@ -1783,7 +1863,7 @@
       },
       "id": 100,
       "options": {
-        "content": "### How to Read\n- Use the month selector to compare any historical period; \"Latest\" always reflects the newest closed month.\n- Time windows: Latest = most recent complete month; trend panels show trailing 12 months; rolling averages use last 3 complete months.\n- Rates are returned as true ratios (0\u20131); keep formatting adjustments in Grafana rather than multiplying by 100 in SQL.\n- Start with low scores or large negative deltas, then drill into linked dashboards for root-cause detail.\n- Forecasts are forward-looking cash expectations; plan around the trajectory, not a single month.",
+        "content": "### How to Read\n- Use the month selector to compare any historical period; \"Latest\" always reflects the newest closed month.\n- Time windows: Latest = most recent complete month; trend panels show trailing 12 months; rolling averages use last 3 complete months.\n- Rates are returned as true ratios (0–1); keep formatting adjustments in Grafana rather than multiplying by 100 in SQL.\n- Start with low scores or large negative deltas, then drill into linked dashboards for root-cause detail.\n- Forecasts are forward-looking cash expectations; plan around the trajectory, not a single month.",
         "mode": "markdown"
       },
       "pluginVersion": "10.0.0",
@@ -1819,6 +1899,46 @@
               {
                 "id": "custom.width",
                 "value": 140
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 10
+                    },
+                    {
+                      "color": "red",
+                      "value": 15
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "View Uncategorized Transactions",
+                    "url": "/d/transaction_analysis_dashboard?var_category=Uncategorized",
+                    "targetBlank": true
+                  }
+                ]
               }
             ]
           },
@@ -1856,7 +1976,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nperiod_bounds AS (\n  SELECT month_date,\n         month_date AS month_start,\n         (month_date + INTERVAL '1 month' - INTERVAL '1 day')::date AS month_end\n  FROM selected_period\n),\nstale_accounts AS (\n  SELECT COUNT(*) AS stale_accounts\n  FROM reporting.dim_accounts_enhanced\n  WHERE account_last_transaction_date < (SELECT month_end FROM period_bounds) - INTERVAL '45 days'\n),\ntransfer_pairs AS (\n  SELECT\n    transaction_date::date AS txn_date,\n    transaction_amount_abs AS amount_abs,\n    SUM(CASE WHEN transaction_amount < 0 THEN 1 ELSE 0 END) AS out_count,\n    SUM(CASE WHEN transaction_amount > 0 THEN 1 ELSE 0 END) AS in_count\n  FROM reporting.fct_transactions_enhanced\n  WHERE COALESCE(is_internal_transfer, FALSE)\n    AND transaction_date >= (SELECT month_start FROM period_bounds)\n    AND transaction_date <= (SELECT month_end FROM period_bounds)\n  GROUP BY 1,2\n),\nunmatched_transfers AS (\n  SELECT COALESCE(SUM(ABS(out_count - in_count)), 0) AS unmatched_count\n  FROM transfer_pairs\n),\nuncategorized AS (\n  SELECT uncategorized_pct\n  FROM reporting.rpt_outflows_insights_dashboard\n  WHERE period_date = (SELECT month_date FROM period_bounds)\n)\nSELECT 'Stale accounts (45d+ no activity)' AS metric,\n       COALESCE((SELECT stale_accounts FROM stale_accounts), 0)::text AS value,\n       'Accounts without recent transactions' AS detail\nUNION ALL\nSELECT 'Unmatched internal transfers',\n       COALESCE((SELECT unmatched_count FROM unmatched_transfers), 0)::text,\n       'Proxy count based on paired in/out amounts'\nUNION ALL\nSELECT 'Uncategorized spend %',\n       CONCAT(ROUND(COALESCE((SELECT uncategorized_pct FROM uncategorized), 0), 1), '%'),\n       'Share of outflows currently uncategorized';",
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_monthly_budget_summary\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nperiod_bounds AS (\n  SELECT month_date,\n         month_date AS month_start,\n         (month_date + INTERVAL '1 month' - INTERVAL '1 day')::date AS month_end\n  FROM selected_period\n),\nstale_accounts AS (\n  SELECT COUNT(*) AS stale_accounts\n  FROM reporting.dim_accounts_enhanced\n  WHERE account_last_transaction_date < (SELECT month_end FROM period_bounds) - INTERVAL '45 days'\n),\ntransfer_pairs AS (\n  SELECT\n    transaction_date::date AS txn_date,\n    transaction_amount_abs AS amount_abs,\n    SUM(CASE WHEN transaction_amount < 0 THEN 1 ELSE 0 END) AS out_count,\n    SUM(CASE WHEN transaction_amount > 0 THEN 1 ELSE 0 END) AS in_count\n  FROM reporting.fct_transactions_enhanced\n  WHERE COALESCE(is_internal_transfer, FALSE)\n    AND transaction_date >= (SELECT month_start FROM period_bounds)\n    AND transaction_date <= (SELECT month_end FROM period_bounds)\n  GROUP BY 1,2\n),\nunmatched_transfers AS (\n  SELECT COALESCE(SUM(ABS(out_count - in_count)), 0) AS unmatched_count\n  FROM transfer_pairs\n),\nuncategorized AS (\n  SELECT uncategorized_pct, uncategorized_amount\n  FROM reporting.rpt_outflows_insights_dashboard\n  WHERE period_date = (SELECT month_date FROM period_bounds)\n)\nSELECT 'Stale accounts (45d+ no activity)' AS metric,\n       COALESCE((SELECT stale_accounts FROM stale_accounts), 0)::text AS value,\n       'Accounts without recent transactions' AS detail\nUNION ALL\nSELECT 'Unmatched internal transfers',\n       COALESCE((SELECT unmatched_count FROM unmatched_transfers), 0)::text,\n       'Proxy count based on paired in/out amounts'\nUNION ALL\nSELECT 'Uncategorized spend',\n       ROUND(COALESCE((SELECT uncategorized_pct FROM uncategorized), 0), 1)::text,\n       CONCAT('$', ROUND(COALESCE((SELECT uncategorized_amount FROM uncategorized), 0), 0)::text, ' uncategorized');",
           "refId": "A"
         }
       ],
@@ -1899,6 +2019,40 @@
                 "value": "time: YYYY-MM-DD"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Contribution %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Merchant"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Categorize Merchant",
+                    "url": "/d/transaction_analysis_dashboard?var_category=Uncategorized",
+                    "targetBlank": true
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1922,7 +2076,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH data AS (\n  SELECT\n    original_memo AS merchant,\n    transaction_count AS txn_count,\n    ROUND(total_amount, 2) AS total_spend,\n    last_transaction_date AS last_seen,\n    priority_level\n  FROM reporting.viz_uncategorized_transactions_with_original_memo\n  ORDER BY total_amount DESC, transaction_count DESC\n  LIMIT 10\n)\nSELECT\n  merchant AS \"Merchant\",\n  txn_count AS \"Txn Count\",\n  total_spend AS \"Total Spend\",\n  last_seen AS \"Last Seen\",\n  priority_level AS \"Priority\"\nFROM data\nUNION ALL\nSELECT 'None', 0, 0, NULL::date, 'N/A'\nWHERE NOT EXISTS (SELECT 1 FROM data);",
+          "rawSql": "WITH data AS (\n  SELECT\n    original_memo AS merchant,\n    txn_count,\n    ROUND(total_amount, 2) AS total_spend,\n    ROUND(contribution_pct, 2) AS contribution_pct,\n    last_transaction_date AS last_seen,\n    priority_level\n  FROM reporting.viz_uncategorized_transactions_with_original_memo\n  ORDER BY total_amount DESC, txn_count DESC\n  LIMIT 10\n)\nSELECT\n  merchant AS \"Merchant\",\n  txn_count AS \"Txn Count\",\n  total_spend AS \"Total Spend\",\n  contribution_pct AS \"Contribution %\",\n  last_seen AS \"Last Seen\",\n  priority_level AS \"Priority\"\nFROM data\nUNION ALL\nSELECT 'None', 0, 0, 0, NULL::date, 'N/A'\nWHERE NOT EXISTS (SELECT 1 FROM data);",
           "refId": "A"
         }
       ],
@@ -1944,7 +2098,10 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null}
+              {
+                "color": "green",
+                "value": null
+              }
             ]
           },
           "unit": "currencyUSD"
@@ -1964,9 +2121,11 @@
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "Total Essentials",
+          "values": true
         },
         "textMode": "auto"
       },
@@ -1998,18 +2157,30 @@
             "mode": "thresholds"
           },
           "mappings": [],
-          "max": 12,
+          "max": 6,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "red", "value": null},
-              {"color": "orange", "value": 1},
-              {"color": "yellow", "value": 3},
-              {"color": "green", "value": 6}
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "green",
+                "value": 6
+              }
             ]
           },
-          "unit": "short"
+          "unit": "month"
         },
         "overrides": []
       },
@@ -2023,7 +2194,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -2061,22 +2234,53 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {"color": "green", "value": null},
-              {"color": "yellow", "value": 0},
-              {"color": "red", "value": 100}
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
             ]
           },
           "unit": "currencyUSD"
         },
         "overrides": [
           {
-            "matcher": {"id": "byName", "options": "pace_status"},
+            "matcher": {
+              "id": "byName",
+              "options": "Pace %"
+            },
             "properties": [
-              {"id": "mappings", "value": [
-                {"options": {"Under Budget": {"color": "green", "index": 0}}, "type": "value"},
-                {"options": {"On Track": {"color": "yellow", "index": 1}}, "type": "value"},
-                {"options": {"Over Budget": {"color": "red", "index": 2}}, "type": "value"}
-              ]}
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 90
+                    },
+                    {
+                      "color": "red",
+                      "value": 110
+                    }
+                  ]
+                }
+              }
             ]
           }
         ]
@@ -2094,7 +2298,9 @@
         "justifyMode": "auto",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": true
         },
@@ -2109,7 +2315,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  wtd_spending AS \"Week Spent\",\n  weekly_budget_target AS \"Weekly Budget\",\n  daily_budget_remaining AS \"Daily Budget Left\",\n  days_remaining_in_week AS \"Days Left\",\n  pace_status\nFROM reporting.rpt_weekly_spending_pace;",
+          "rawSql": "SELECT\n  wtd_spending AS \"Week Spent\",\n  weekly_budget_target AS \"Weekly Budget\",\n  ROUND((wtd_spending / NULLIF(wtd_budget_target, 0) * 100)::numeric, 1) AS \"Pace %\",\n  daily_budget_remaining AS \"Daily Budget Left\",\n  days_remaining_in_week AS \"Days Left\",\n  wtd_budget_target AS \"Expected Spend\"\nFROM reporting.rpt_weekly_spending_pace;",
           "refId": "A"
         }
       ],

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_emergency_fund_coverage.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_emergency_fund_coverage.sql
@@ -55,7 +55,7 @@ expense_history AS (
     budget_year_month,
     total_expenses,
     -- Essential expenses approximation (mortgage + household + food + family + health)
-    mortgage_expenses + household_expenses + food_expenses + family_expenses AS essential_expenses,
+    COALESCE(mortgage_expenses, 0) + COALESCE(household_expenses, 0) + COALESCE(food_expenses, 0) + COALESCE(family_expenses, 0) AS essential_expenses,
     -- Individual category breakdowns
     mortgage_expenses,
     household_expenses,
@@ -95,11 +95,7 @@ emergency_fund_calc AS (
     END AS months_total_expenses_covered,
 
     -- Months of essential expenses covered (more conservative)
-    CASE
-      WHEN ae.avg_monthly_essential_expenses > 0
-      THEN ROUND((nw.liquid_assets / ae.avg_monthly_essential_expenses)::numeric, 1)
-      ELSE 0
-    END AS months_essential_expenses_covered,
+    ROUND((nw.liquid_assets / NULLIF(ae.avg_monthly_essential_expenses, 0))::numeric, 1) AS months_essential_expenses_covered,
 
     -- Target coverage (6 months for family with young kids)
     6.0 AS target_months_coverage,

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
@@ -44,23 +44,23 @@ monthly_totals AS (
     transaction_month,
 
     -- Groceries (Food & Drink category, typically groceries subcategory)
-    SUM(CASE WHEN level_1_category = 'Food & Drink' THEN category_spending ELSE 0 END) AS groceries_spending,
+    COALESCE(SUM(CASE WHEN level_1_category = 'Food & Drink' THEN category_spending ELSE 0 END), 0) AS groceries_spending,
     SUM(CASE WHEN level_1_category = 'Food & Drink' THEN transaction_count ELSE 0 END) AS groceries_transactions,
 
     -- Family & Kids (childcare, activities, supplies)
-    SUM(CASE WHEN level_1_category = 'Family & Kids' THEN category_spending ELSE 0 END) AS family_kids_spending,
+    COALESCE(SUM(CASE WHEN level_1_category = 'Family & Kids' THEN category_spending ELSE 0 END), 0) AS family_kids_spending,
     SUM(CASE WHEN level_1_category = 'Family & Kids' THEN transaction_count ELSE 0 END) AS family_kids_transactions,
 
     -- Health & Medical
-    SUM(CASE WHEN level_1_category = 'Health & Beauty' THEN category_spending ELSE 0 END) AS health_spending,
+    COALESCE(SUM(CASE WHEN level_1_category = 'Health & Beauty' THEN category_spending ELSE 0 END), 0) AS health_spending,
     SUM(CASE WHEN level_1_category = 'Health & Beauty' THEN transaction_count ELSE 0 END) AS health_transactions,
 
     -- Household essentials
-    SUM(CASE WHEN level_1_category = 'Household & Services' THEN category_spending ELSE 0 END) AS household_spending,
+    COALESCE(SUM(CASE WHEN level_1_category = 'Household & Services' THEN category_spending ELSE 0 END), 0) AS household_spending,
     SUM(CASE WHEN level_1_category = 'Household & Services' THEN transaction_count ELSE 0 END) AS household_transactions,
 
     -- Total family essentials
-    SUM(category_spending) AS total_family_essentials,
+    COALESCE(SUM(category_spending), 0) AS total_family_essentials,
     SUM(transaction_count) AS total_transactions
 
   FROM monthly_family_spending

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_household_net_worth.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_household_net_worth.sql
@@ -70,7 +70,7 @@ monthly_net_worth_calculation AS (
 
     -- Asset values (use absolute values for display)
     SUM(CASE
-      WHEN account_type != 'liability' THEN ABS(end_of_month_balance)
+      WHEN NOT is_liability THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS total_assets,
     SUM(CASE
@@ -78,22 +78,22 @@ monthly_net_worth_calculation AS (
       ELSE 0
     END) AS property_assets,
     SUM(CASE
-      WHEN account_type NOT IN ('liability', 'Property') THEN ABS(end_of_month_balance)
+      WHEN NOT is_liability AND account_type != 'Property' THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS non_property_assets,
 
     -- Liability values (use absolute values for display)
     SUM(CASE
-      WHEN account_type = 'liability' THEN ABS(end_of_month_balance)
+      WHEN is_liability THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS total_liabilities,
 
     -- Net worth calculation (assets - liabilities)
     SUM(CASE
-      WHEN account_type != 'liability' THEN ABS(end_of_month_balance)
+      WHEN NOT is_liability THEN ABS(end_of_month_balance)
       ELSE 0
     END) - SUM(CASE
-      WHEN account_type = 'liability' THEN ABS(end_of_month_balance)
+      WHEN is_liability THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS net_worth,
     

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_household_net_worth.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_household_net_worth.sql
@@ -63,35 +63,38 @@ monthly_account_balances AS (
 ),
 
 monthly_net_worth_calculation AS (
-  SELECT 
+  SELECT
     budget_year_month,
     transaction_year,
     transaction_month,
-    
-    -- Asset values (positive balances for assets, absolute value for display)
-    SUM(CASE 
-      WHEN NOT is_liability THEN end_of_month_balance 
-      ELSE 0 
+
+    -- Asset values (use absolute values for display)
+    SUM(CASE
+      WHEN account_type != 'liability' THEN ABS(end_of_month_balance)
+      ELSE 0
     END) AS total_assets,
-    SUM(CASE 
-      WHEN account_type = 'Property' THEN end_of_month_balance
+    SUM(CASE
+      WHEN account_type = 'Property' THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS property_assets,
-    SUM(CASE 
-      WHEN NOT is_liability AND account_type <> 'Property' THEN end_of_month_balance
+    SUM(CASE
+      WHEN account_type NOT IN ('liability', 'Property') THEN ABS(end_of_month_balance)
       ELSE 0
     END) AS non_property_assets,
-    
-    -- Liability values (negative balances for liabilities, show as positive for readability)
-    SUM(CASE 
-      WHEN is_liability THEN ABS(end_of_month_balance)
-      ELSE 0 
+
+    -- Liability values (use absolute values for display)
+    SUM(CASE
+      WHEN account_type = 'liability' THEN ABS(end_of_month_balance)
+      ELSE 0
     END) AS total_liabilities,
-    
+
     -- Net worth calculation (assets - liabilities)
-    SUM(CASE 
-      WHEN NOT is_liability THEN end_of_month_balance 
-      ELSE -ABS(end_of_month_balance)
+    SUM(CASE
+      WHEN account_type != 'liability' THEN ABS(end_of_month_balance)
+      ELSE 0
+    END) - SUM(CASE
+      WHEN account_type = 'liability' THEN ABS(end_of_month_balance)
+      ELSE 0
     END) AS net_worth,
     
     -- Breakdown by account categories
@@ -186,11 +189,11 @@ net_worth_trends AS (
 ),
 
 net_worth_analysis AS (
-  SELECT 
+  SELECT
     *,
     (total_assets - property_assets - liquid_assets) AS other_assets,
     -- Financial ratios
-    CASE WHEN total_assets > 0 THEN (total_liabilities / total_assets) ELSE 0 END AS debt_to_asset_ratio,
+    total_liabilities / NULLIF(total_assets, 0) AS debt_to_asset_ratio,
     CASE WHEN total_liabilities > 0 THEN (liquid_assets / total_liabilities) ELSE NULL END AS liquidity_ratio,
     CASE WHEN total_assets > 0 THEN (net_worth / total_assets) ELSE 0 END AS equity_ratio,
     

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_mom_cash_flow_waterfall.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_mom_cash_flow_waterfall.sql
@@ -1,0 +1,159 @@
+{{
+  config(
+    materialized='table',
+    indexes=[
+      {'columns': ['budget_year_month'], 'unique': true}
+    ]
+  )
+}}
+
+-- Month-over-Month Cash Flow Waterfall Drivers
+-- Calculates deltas between selected and previous month for income, expenses, transfers, and net cash flow
+-- Output format designed for waterfall visualizations showing what drove the change in net cash flow
+
+WITH available_months AS (
+  SELECT budget_year_month,
+         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date
+  FROM {{ ref('rpt_monthly_budget_summary') }}
+  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')
+),
+
+-- Get current month data from both budget summary and cash flow analysis
+current_month AS (
+  SELECT
+    bs.budget_year_month,
+    bs.total_income,
+    bs.total_expenses,
+    bs.net_cash_flow,
+    cf.total_internal_transfers,
+    to_date(bs.budget_year_month || '-01', 'YYYY-MM-DD') AS month_date
+  FROM {{ ref('rpt_monthly_budget_summary') }} bs
+  LEFT JOIN {{ ref('rpt_cash_flow_analysis') }} cf
+    ON bs.budget_year_month = cf.budget_year_month
+),
+
+-- Get previous month data
+previous_month AS (
+  SELECT
+    cm.budget_year_month AS current_month_key,
+    bs.total_income AS prev_income,
+    bs.total_expenses AS prev_expenses,
+    bs.net_cash_flow AS prev_net_cash_flow,
+    cf.total_internal_transfers AS prev_internal_transfers
+  FROM current_month cm
+  CROSS JOIN LATERAL (
+    SELECT budget_year_month,
+           to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date
+    FROM available_months
+    WHERE month_date < cm.month_date
+    ORDER BY month_date DESC
+    LIMIT 1
+  ) prev_month
+  LEFT JOIN {{ ref('rpt_monthly_budget_summary') }} bs
+    ON prev_month.budget_year_month = bs.budget_year_month
+  LEFT JOIN {{ ref('rpt_cash_flow_analysis') }} cf
+    ON prev_month.budget_year_month = cf.budget_year_month
+),
+
+-- Calculate deltas for waterfall
+waterfall_deltas AS (
+  SELECT
+    cm.budget_year_month,
+    cm.month_date,
+
+    -- Current month values
+    cm.total_income AS current_income,
+    cm.total_expenses AS current_expenses,
+    cm.total_internal_transfers AS current_internal_transfers,
+    cm.net_cash_flow AS current_net_cash_flow,
+
+    -- Previous month values
+    COALESCE(pm.prev_income, 0) AS previous_income,
+    COALESCE(pm.prev_expenses, 0) AS previous_expenses,
+    COALESCE(pm.prev_internal_transfers, 0) AS previous_internal_transfers,
+    COALESCE(pm.prev_net_cash_flow, 0) AS previous_net_cash_flow,
+
+    -- Delta calculations for waterfall
+    -- Income increase = positive contribution to net cash flow
+    cm.total_income - COALESCE(pm.prev_income, 0) AS income_delta,
+
+    -- Expense increase = negative contribution (hence the negation)
+    -- If expenses increased, this will be negative; if decreased, positive
+    -(cm.total_expenses - COALESCE(pm.prev_expenses, 0)) AS expense_delta,
+
+    -- Transfer change (net impact on cash position)
+    COALESCE(cm.total_internal_transfers, 0) - COALESCE(pm.prev_internal_transfers, 0) AS transfers_delta,
+
+    -- Net delta (should equal sum of above deltas)
+    cm.net_cash_flow - COALESCE(pm.prev_net_cash_flow, 0) AS net_delta,
+
+    CURRENT_TIMESTAMP AS report_generated_at
+
+  FROM current_month cm
+  LEFT JOIN previous_month pm
+    ON cm.budget_year_month = pm.current_month_key
+)
+
+-- Unpivot deltas into rows for waterfall visualization
+SELECT
+  budget_year_month,
+  month_date,
+
+  -- Row 1: Income contribution
+  'Income' AS driver,
+  1 AS sort_order,
+  income_delta AS delta_amount,
+  current_income,
+  previous_income,
+
+  -- Metadata
+  report_generated_at
+
+FROM waterfall_deltas
+
+UNION ALL
+
+-- Row 2: Expense contribution (already negated)
+SELECT
+  budget_year_month,
+  month_date,
+  'Expenses' AS driver,
+  2 AS sort_order,
+  expense_delta AS delta_amount,
+  current_expenses,
+  previous_expenses,
+  report_generated_at
+
+FROM waterfall_deltas
+
+UNION ALL
+
+-- Row 3: Transfers contribution
+SELECT
+  budget_year_month,
+  month_date,
+  'Transfers' AS driver,
+  3 AS sort_order,
+  transfers_delta AS delta_amount,
+  current_internal_transfers,
+  previous_internal_transfers,
+  report_generated_at
+
+FROM waterfall_deltas
+
+UNION ALL
+
+-- Row 4: Net result
+SELECT
+  budget_year_month,
+  month_date,
+  'Net Change' AS driver,
+  4 AS sort_order,
+  net_delta AS delta_amount,
+  current_net_cash_flow AS current_income,
+  previous_net_cash_flow AS previous_income,
+  report_generated_at
+
+FROM waterfall_deltas
+
+ORDER BY budget_year_month DESC, sort_order

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_mom_cash_flow_waterfall.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_mom_cash_flow_waterfall.sql
@@ -2,7 +2,7 @@
   config(
     materialized='table',
     indexes=[
-      {'columns': ['budget_year_month'], 'unique': true}
+      {'columns': ['budget_year_month', 'driver'], 'unique': true}
     ]
   )
 }}

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_outflows_insights_dashboard.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_outflows_insights_dashboard.sql
@@ -62,7 +62,7 @@ top_drivers AS (
 uncategorized_analysis AS (
   SELECT
     ao.period_date,
-    ao.uncategorized,
+    ao.uncategorized AS uncategorized_amount,
     CASE WHEN ao.total_outflows > 0 THEN (ao.uncategorized / ao.total_outflows) * 100 ELSE 0 END AS uncategorized_pct,
 
     -- Previous month uncategorized for comparison
@@ -419,7 +419,7 @@ final_report AS (
     ss.transportation_pct,
     ss.shopping_retail,
     ss.shopping_retail_pct,
-    ss.uncategorized,
+    ss.uncategorized AS uncategorized_amount,
     ss.uncategorized_pct,
     ss.mom_uncategorized_change_pct,
 

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_weekly_spending_pace.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_weekly_spending_pace.sql
@@ -96,7 +96,11 @@ SELECT
 
   -- Week-to-date pacing
   ROUND((wt.daily_budget_target * wt.current_day_of_week)::numeric, 2) AS wtd_budget_target,
+  ROUND((wt.daily_budget_target * wt.current_day_of_week)::numeric, 2) AS expected_spend_to_date,
   COALESCE(wtx.wtd_spending, 0) - ROUND((wt.daily_budget_target * wt.current_day_of_week)::numeric, 2) AS wtd_variance,
+
+  -- Pace ratio (percentage)
+  ROUND((COALESCE(wtx.wtd_spending, 0) / NULLIF(ROUND((wt.daily_budget_target * wt.current_day_of_week)::numeric, 2), 0) * 100)::numeric, 1) AS pace_ratio,
 
   -- Daily budget remaining for rest of week
   CASE

--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/schema.yml
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/schema.yml
@@ -654,6 +654,28 @@ models:
         description: Score (0-100) indicating spending consistency with this vendor
         data_type: numeric
 
+  - name: rpt_mom_cash_flow_waterfall
+    description: "Month-over-month cash flow waterfall showing drivers of change (income, expenses, transfers, net)"
+    columns:
+      - name: budget_year_month
+        description: "YYYY-MM format for the current month"
+        tests:
+          - not_null
+      - name: driver
+        description: "Cash flow driver category (Income, Expenses, Transfers, Net Change)"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Income', 'Expenses', 'Transfers', 'Net Change']
+      - name: delta_amount
+        description: "Dollar change from previous month (positive = improvement to net cash flow)"
+        tests:
+          - not_null
+      - name: sort_order
+        description: "Display order for waterfall visualization (1-4)"
+        tests:
+          - not_null
+
   - name: rpt_financial_health_scorecard
     description: |
       Comprehensive financial health scorecard providing multi-dimensional assessment


### PR DESCRIPTION
## Summary

This PR completes all 10 dashboard fix tasks (21-30) from plan.md, improving data accuracy, visualization clarity, and actionability across the Executive Financial Dashboard.

## Changes Overview

### Stat Panel Fixes (4 tasks)

**Task 21: Fix Family Essentials stat**
- Added COALESCE to all spending aggregations in `rpt_family_essentials.sql` to default to 0 instead of NULL
- Updated Grafana panel to set `reduceOptions.values=true` and display only Total Essentials field

**Task 23: Restore Monthly Financial Snapshot**
- Changed data source from `rpt_monthly_budget_summary` to `rpt_cash_flow_analysis`
- Updated field mappings to use `total_inflows`/`total_outflows` with COALESCE wrapping
- Currency unit (currencyUSD) maintained

**Task 28: Improve Week-to-Date Spending Pace**
- Added `pace_ratio` calculation: `wtd_spending / NULLIF(expected_spend_to_date, 0) * 100`
- Added `expected_spend_to_date` field for clarity
- Updated Grafana stat with percent unit and color-coded thresholds (<90 green, 90-110 yellow, >110 red)

**Task 29: Tighten Emergency Fund Coverage**
- Fixed `essential_expenses` calculation using COALESCE on all components
- Simplified months coverage calculation with NULLIF for safe division
- Updated Grafana gauge: max 6 months (was 12), proper month unit

### Chart Visualizations (3 tasks)

**Task 22: Correct Asset & Liability Snapshot sign logic**
- Updated to use `ABS(end_of_month_balance)` for all calculations
- Changed to `account_type != 'liability'` for assets, `account_type = 'liability'` for liabilities
- Fixed net_worth calculation: `total_assets - total_liabilities`
- Updated debt_to_asset_ratio with NULLIF handling

**Task 24: Fix Savings & Expense Performance percentages**
- Added 0-100 percent columns: `savings_rate_pct`, `savings_rate_3m_pct`, `savings_rate_ytd_pct`, `expense_ratio_pct`
- Changed Grafana bar gauge from `percentunit` to `percent` unit
- Set thresholds at 5/10/20/30 with min 0 max 100

**Task 25: Align Cash Flow Trend forecast**
- Added `+ interval '1 month'` to shift forecast dates forward by one month
- Split query into separate result sets for historical vs forecast data
- Updated visualization: bars for Net Cash Flow, line for 3-Month Avg, dashed line with light fill for Forecast

### Table Panel Improvements (2 tasks)

**Task 26: Make Data Quality Callouts numeric and actionable**
- Returned `uncategorized_pct` as numeric value (no % string) and exposed `uncategorized_amount`
- Added Grafana percent unit with thresholds (green <10, yellow 10-15, red >15)
- Added cell background coloring and link to `/d/transaction_analysis_dashboard?var_category=Uncategorized`

**Task 27: Add actionability to Top Uncategorized Merchants**
- Added `contribution_pct` calculation: `total_amount / sum of all uncategorized * 100`
- Added filtering: `WHERE txn_count>=2 OR total_amount>=100` to focus on patterns
- Updated Grafana table with Contribution % column (percent unit, 2 decimals)
- Added URL link per merchant to categorization workflow

### Waterfall Visualization (1 task)

**Task 30: Replace MoM Cash table with drivers waterfall**
- Created new dbt model `rpt_mom_cash_flow_waterfall.sql` calculating month-over-month deltas:
  - `income_delta` = current income - previous income
  - `expense_delta` = -(current expenses - previous expenses) [negated so decreases show as positive]
  - `transfers_delta` = current transfers - previous transfers
  - `net_delta` = current net cash flow - previous net cash flow
- Unpivots deltas into 4 rows per month with sort_order
- Replaced "Month-over-Month Cash Changes" table with horizontal bar chart waterfall
- Color thresholds: Red (<0), Green (>=0), Blue for Net Change
- Added schema documentation

## Files Modified

**dbt SQL Models (8 files)**
- `rpt_emergency_fund_coverage.sql`
- `rpt_family_essentials.sql`
- `rpt_household_net_worth.sql`
- `rpt_monthly_budget_summary.sql`
- `rpt_outflows_insights_dashboard.sql`
- `rpt_weekly_spending_pace.sql`
- `viz_uncategorized_transactions_with_original_memo.sql`
- `schema.yml`

**New dbt Model (1 file)**
- `rpt_mom_cash_flow_waterfall.sql`

**Grafana Dashboards (1 file)**
- `executive-dashboard.json`

## Testing Checklist

- [ ] Run `dbt run` to materialize updated models
- [ ] Verify new `rpt_mom_cash_flow_waterfall` model builds successfully
- [ ] Restart Grafana or reload provisioned dashboards
- [ ] Verify all 10 panels display data correctly in Executive Dashboard:
  - [ ] Family Essentials (Last Month) - shows total value
  - [ ] Asset & Liability Snapshot - positive values for assets
  - [ ] Monthly Financial Snapshot - shows income/expense values
  - [ ] Savings & Expense Performance - percentages in 0-100 range
  - [ ] Cash Flow Trend - forecast appears one month ahead
  - [ ] Data Quality Callouts - numeric percentage with links
  - [ ] Top Uncategorized Merchants - contribution % and links
  - [ ] Week-to-Date Spending Pace - pace ratio with color coding
  - [ ] Emergency Fund Coverage - max 6 months scale
  - [ ] Cash Flow Drivers (MoM) - waterfall bar chart

## Related Issues

Addresses tasks 21-30 from plan.md

## Additional Notes

- All SQL uses COALESCE and NULLIF for safe NULL handling
- Grafana panels properly configured with correct units and thresholds
- Field mappings align between SQL output and Grafana visualization
- Currency formatting uses USD as specified in CLAUDE.md
- All changes follow existing code patterns and project standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)