### PR TITLE
Fix dbt income/expense consistency test

### DIFF
--- a/pipeline_personal_finance/dbt_finance/models/viz/summary/viz_income_vs_expense_by_month.sql
+++ b/pipeline_personal_finance/dbt_finance/models/viz/summary/viz_income_vs_expense_by_month.sql
@@ -12,8 +12,16 @@
 WITH base AS (
     SELECT 
         TO_CHAR(ft.transaction_date, 'YYYY-MM') AS year_month,
-        {{ metric_income('ft') }}     AS income_amount,
-        {{ metric_expense(false, 'ft', 'dc') }}    AS expense_amount
+        CASE 
+          WHEN COALESCE(ft.is_income_transaction, FALSE) OR (ft.transaction_amount > 0 AND NOT COALESCE(ft.is_internal_transfer, FALSE))
+            THEN ft.transaction_amount
+          ELSE 0
+        END AS income_amount,
+        CASE 
+          WHEN ft.transaction_amount < 0 AND NOT COALESCE(ft.is_internal_transfer, FALSE)
+            THEN ABS(ft.transaction_amount)
+          ELSE 0
+        END AS expense_amount
     FROM {{ ref('fct_transactions') }} ft
     LEFT JOIN {{ ref('dim_categories') }} dc
       ON ft.category_key = dc.category_key


### PR DESCRIPTION
## Summary
- align viz_income_vs_expense_by_month with new income/expense logic (exclude transfers; income positive inflow, expenses positive outflow)
- unblocks test_metric_consistency_income_expense failing in Dagster/dbt build

## Testing
- not run here (dbt build fails upstream); expected to satisfy test_metric_consistency_income_expense