### PR TITLE
Fix family essentials grouping (dbt build error)

### DIFF
--- a/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
+++ b/pipeline_personal_finance/dbt_finance/models/reporting/budget/rpt_family_essentials.sql
@@ -49,8 +49,9 @@ monthly_family_spending AS (
   LEFT JOIN {{ ref('dim_categories') }} dc ON ft.category_key = dc.category_key
   WHERE dc.level_1_category IN ('Food & Drink', 'Family & Kids', 'Health & Beauty', 'Household & Services')
   GROUP BY
-    ft.transaction_year,
-    ft.transaction_month,
+    ms.transaction_year,
+    ms.transaction_month,
+    ms.budget_year_month,
     dc.level_1_category,
     dc.level_2_subcategory
 ),


### PR DESCRIPTION
## Summary
- add budget_year_month and month keys to GROUP BY in rpt_family_essentials to satisfy Postgres grouping
- keeps latest-month anchoring and non-transfer expense logic intact

## Testing
- not run (dbt build should now pass test family essentials model creation)