### PR TITLE
Task 29: tighten emergency fund coverage gauge and latest-month basis

### DIFF
--- a/grafana/provisioning/dashboards/executive-dashboard.json
+++ b/grafana/provisioning/dashboards/executive-dashboard.json
@@ -2247,8 +2247,8 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "",
-          "values": false
+          "fields": "Months Covered",
+          "values": true
         },
         "showThresholdLabels": true,
         "showThresholdMarkers": true


### PR DESCRIPTION
## Summary
- switch emergency-fund coverage math to use latest-month expenses for the primary KPI and gap-to-target
- retain 6-month averages as supplemental context fields in the model output
- bind Grafana gauge reduction to the numeric "Months Covered" field to avoid status-text reduction issues

## Why
The dashboard should answer whether current liquid assets cover current essential burn; using older averages can hide recent changes.

## Validation
- executed transformed SQL logic against local DuckDB data and verified expected output row for latest month
- verified diff scope is limited to model + executive dashboard gauge panel
