### PR TITLE
Task 2: create Childcare & Early Education subcategory mappings

### DIFF
--- a/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
+++ b/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
@@ -245,3 +245,57 @@ RAINBOW MEATS,,,,ing_countdown,Food & Drink,Groceries,RAINBOW,External
 534 BARKLY ST DTL P/L,,,,bendigo_offset,Health & Beauty,Dentist,534 BARKLY ST,External
 534 BARKLY ST DTL P/L,,,,ing_billsbillsbills,Health & Beauty,Dentist,534 BARKLY ST,External
 534 BARKLY ST DTL P/L,,,,ing_countdown,Health & Beauty,Dentist,534 BARKLY ST,External
+GOODSTART EARLY LEARNING,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Goodstart,External
+GOODSTART EARLY LEARNING,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Goodstart,External
+GOODSTART EARLY LEARNING,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Goodstart,External
+GOODSTART EARLY LEARNING,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Goodstart,External
+GOODSTART EARLY LEARNING,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Goodstart,External
+GOODSTART EARLY LEARNING,,,,ing_countdown,Family & Kids,Childcare & Early Education,Goodstart,External
+YMCA EARLY LEARNING,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+YMCA EARLY LEARNING,,,,adelaide_offset,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+YMCA EARLY LEARNING,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+YMCA EARLY LEARNING,,,,bendigo_offset,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+YMCA EARLY LEARNING,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+YMCA EARLY LEARNING,,,,ing_countdown,Family & Kids,Childcare & Early Education,YMCA Early Learning,External
+CHILDCARE FEES,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Childcare Fees,External
+CHILDCARE FEES,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Childcare Fees,External
+CHILDCARE FEES,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Childcare Fees,External
+CHILDCARE FEES,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Childcare Fees,External
+CHILDCARE FEES,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Childcare Fees,External
+CHILDCARE FEES,,,,ing_countdown,Family & Kids,Childcare & Early Education,Childcare Fees,External
+DAYCARE FEES,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Daycare Fees,External
+DAYCARE FEES,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Daycare Fees,External
+DAYCARE FEES,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Daycare Fees,External
+DAYCARE FEES,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Daycare Fees,External
+DAYCARE FEES,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Daycare Fees,External
+DAYCARE FEES,,,,ing_countdown,Family & Kids,Childcare & Early Education,Daycare Fees,External
+PRESCHOOL FEES,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Preschool Fees,External
+PRESCHOOL FEES,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Preschool Fees,External
+PRESCHOOL FEES,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Preschool Fees,External
+PRESCHOOL FEES,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Preschool Fees,External
+PRESCHOOL FEES,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Preschool Fees,External
+PRESCHOOL FEES,,,,ing_countdown,Family & Kids,Childcare & Early Education,Preschool Fees,External
+KINDERGARTEN FEES,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+KINDERGARTEN FEES,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+KINDERGARTEN FEES,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+KINDERGARTEN FEES,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+KINDERGARTEN FEES,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+KINDERGARTEN FEES,,,,ing_countdown,Family & Kids,Childcare & Early Education,Kindergarten Fees,External
+OSHC FEES,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,OSHC,External
+OSHC FEES,,,,adelaide_offset,Family & Kids,Childcare & Early Education,OSHC,External
+OSHC FEES,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,OSHC,External
+OSHC FEES,,,,bendigo_offset,Family & Kids,Childcare & Early Education,OSHC,External
+OSHC FEES,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,OSHC,External
+OSHC FEES,,,,ing_countdown,Family & Kids,Childcare & Early Education,OSHC,External
+AFTER SCHOOL CARE,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,After School Care,External
+AFTER SCHOOL CARE,,,,adelaide_offset,Family & Kids,Childcare & Early Education,After School Care,External
+AFTER SCHOOL CARE,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,After School Care,External
+AFTER SCHOOL CARE,,,,bendigo_offset,Family & Kids,Childcare & Early Education,After School Care,External
+AFTER SCHOOL CARE,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,After School Care,External
+AFTER SCHOOL CARE,,,,ing_countdown,Family & Kids,Childcare & Early Education,After School Care,External
+BABYSITTING,,,,adelaide_homeloan,Family & Kids,Childcare & Early Education,Babysitting,External
+BABYSITTING,,,,adelaide_offset,Family & Kids,Childcare & Early Education,Babysitting,External
+BABYSITTING,,,,bendigo_homeloan,Family & Kids,Childcare & Early Education,Babysitting,External
+BABYSITTING,,,,bendigo_offset,Family & Kids,Childcare & Early Education,Babysitting,External
+BABYSITTING,,,,ing_billsbillsbills,Family & Kids,Childcare & Early Education,Babysitting,External
+BABYSITTING,,,,ing_countdown,Family & Kids,Childcare & Early Education,Babysitting,External


### PR DESCRIPTION
## Summary
- add explicit `Family & Kids -> Childcare & Early Education` mappings in `banking_categories.csv`
- cover common childcare memo patterns: Goodstart, YMCA early learning, childcare/daycare/preschool/kindergarten fees, OSHC, after school care, and babysitting
- apply each pattern across all six active account names to keep matching behavior consistent

## Validation
- python CSV parse check: all rows parse and 54 childcare rows present
- dbt deps --project-dir pipeline_personal_finance/dbt_finance
- dbt seed --project-dir pipeline_personal_finance/dbt_finance --select banking_categories --target local_duckdb