### PR TITLE
Task 12: add configurable cost-per-child panel

### DIFF
--- a/grafana/provisioning/dashboards/executive-dashboard.json
+++ b/grafana/provisioning/dashboards/executive-dashboard.json
@@ -2161,7 +2161,7 @@
       "gridPos": {
         "x": 0,
         "y": 59,
-        "w": 12,
+        "w": 6,
         "h": 4
       },
       "id": 1001,
@@ -2193,6 +2193,68 @@
         }
       ],
       "title": "Family Essentials (Last Month)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "description": "Estimated Family & Kids spending per child for the selected window. Adjust the Children variable to match your household.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 59,
+        "w": 6,
+        "h": 4
+      },
+      "id": 1005,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "Cost Per Child",
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "WITH available_months AS (\n  SELECT budget_year_month,\n         to_date(budget_year_month || '-01', 'YYYY-MM-DD') AS month_date\n  FROM reporting.rpt_family_essentials\n  WHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM')\n),\nlatest_period AS (\n  SELECT MAX(month_date) AS month_date\n  FROM available_months\n),\nselected_period AS (\n  SELECT CASE\n           WHEN '${dashboard_period}' = 'Latest' OR coalesce('${dashboard_period}', '') = ''\n             THEN (SELECT month_date FROM latest_period)\n           ELSE to_date('${dashboard_period}' || '-01', 'YYYY-MM-DD')\n         END AS month_date\n),\nwindow_range AS (\n  SELECT\n    CASE '${time_window}'\n      WHEN 'ytd'          THEN DATE_TRUNC('year', (SELECT month_date FROM selected_period))\n      WHEN 'trailing_12m' THEN (SELECT month_date FROM selected_period) - INTERVAL '11 months'\n      ELSE                     (SELECT month_date FROM selected_period)\n    END AS start_date,\n    (SELECT month_date FROM selected_period) AS end_date\n),\nfamily_costs AS (\n  SELECT COALESCE(SUM(family_kids_spending), 0) AS family_kids_total\n  FROM reporting.rpt_family_essentials\n  WHERE to_date(budget_year_month || '-01', 'YYYY-MM-DD')\n        BETWEEN (SELECT start_date FROM window_range)\n        AND     (SELECT end_date   FROM window_range)\n),\nchild_count AS (\n  SELECT CASE\n           WHEN '${child_count}' ~ '^[0-9]+$' THEN '${child_count}'::numeric\n           ELSE 3\n         END AS children\n)\nSELECT\n  ROUND(fc.family_kids_total / NULLIF(cc.children, 0), 2) AS \"Cost Per Child\"\nFROM family_costs fc\nCROSS JOIN child_count cc;",
+          "refId": "A"
+        }
+      ],
+      "title": "Cost Per Child (Est.)",
       "type": "stat"
     },
     {
@@ -2688,6 +2750,54 @@
         "regex": "",
         "skipUrlSync": false,
         "allowCustom": false
+      },
+      {
+        "name": "child_count",
+        "label": "Children",
+        "type": "custom",
+        "hide": 0,
+        "current": {
+          "text": "3",
+          "value": "3",
+          "selected": true
+        },
+        "options": [
+          {
+            "text": "1",
+            "value": "1",
+            "selected": false
+          },
+          {
+            "text": "2",
+            "value": "2",
+            "selected": false
+          },
+          {
+            "text": "3",
+            "value": "3",
+            "selected": true
+          },
+          {
+            "text": "4",
+            "value": "4",
+            "selected": false
+          },
+          {
+            "text": "5",
+            "value": "5",
+            "selected": false
+          },
+          {
+            "text": "6",
+            "value": "6",
+            "selected": false
+          }
+        ],
+        "query": "1,2,3,4,5,6",
+        "includeAll": false,
+        "multi": false,
+        "skipUrlSync": false,
+        "allowCustom": true
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add a new Executive dashboard stat panel: `Cost Per Child (Est.)`
- compute per-child cost from `reporting.rpt_family_essentials.family_kids_spending` scoped to selected `dashboard_period` + `time_window`
- add a configurable dashboard variable `child_count` (default `3`) so households can adjust estimate input
- rebalance the hero family row width so `Family Essentials` and `Cost Per Child` sit side-by-side before Emergency Fund and MTD Pace

## Validation
- `python -m json.tool grafana/provisioning/dashboards/executive-dashboard.json`
- SQL guard added so unresolved `${child_count}` safely defaults to `3` in non-Grafana validation contexts