### PR TITLE
Enforce strict dashboard quality gate on empty panels

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,9 +41,8 @@ GRAFANA_URL=http://grafana:3000
 
 # Dashboard QA Gate Configuration
 # DASHBOARD_POLICY_GATE_WARN_ONLY: set to "true" to log policy violations without failing
-# the pipeline. Use during interim rollout phases while SQL macro wiring is still in progress.
-# Set to "false" (or remove) once all dashboards have completed the time-control migration.
-DASHBOARD_POLICY_GATE_WARN_ONLY=true
+# the pipeline. Default is "false" — violations block the pipeline.
+DASHBOARD_POLICY_GATE_WARN_ONLY=false
 
 # Password Generation Helper:
 # Use this command to generate strong passwords:

--- a/.env.template
+++ b/.env.template
@@ -43,6 +43,9 @@ GRAFANA_URL=http://grafana:3000
 # DASHBOARD_POLICY_GATE_WARN_ONLY: set to "true" to log policy violations without failing
 # the pipeline. Default is "false" — violations block the pipeline.
 DASHBOARD_POLICY_GATE_WARN_ONLY=false
+# DASHBOARD_QUALITY_WARN_ONLY: set to "true" to log empty-panel failures without failing
+# the pipeline. Default is "false" — empty panels block the pipeline.
+DASHBOARD_QUALITY_WARN_ONLY=false
 
 # Password Generation Helper:
 # Use this command to generate strong passwords:

--- a/dagster_core/dagster.yaml
+++ b/dagster_core/dagster.yaml
@@ -33,6 +33,7 @@ run_launcher:
       - GRAFANA_URL
       - DBT_EXECUTION_CONTEXT
       - DASHBOARD_POLICY_GATE_WARN_ONLY
+      - DASHBOARD_QUALITY_WARN_ONLY
     network: qif_personal_finance_dagster_network
     container_kwargs:
       volumes: # Make docker client accessible to any launched containers as well

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -14,7 +14,7 @@ services:
 
   pipeline_personal_finance:
     volumes:
-      - ./scripts:/opt/dagster/app/scripts:ro
+      - ./scripts:${DAGSTER_APP}/scripts:ro
 
   dagster_webserver:
     # Expose on 3002 to avoid conflict with any service already on 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,12 +115,12 @@ services:
       GRAFANA_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       POSTGRES_ADMIN_USER: ${POSTGRES_ADMIN_USER}
       POSTGRES_ADMIN_PASSWORD: ${POSTGRES_ADMIN_PASSWORD}
-      DASHBOARD_DIR: /opt/dagster/app/grafana/provisioning/dashboards
+      DASHBOARD_DIR: ${DAGSTER_APP}/grafana/provisioning/dashboards
       DBT_EXECUTION_CONTEXT: dagster
     volumes:
       - /tmp/dagster-data:/tmp/dagster-data
-      - ./pipeline_personal_finance/qif_files:/opt/dagster/app/pipeline_personal_finance/qif_files
-      - ./grafana/provisioning/dashboards:/opt/dagster/app/grafana/provisioning/dashboards:ro
+      - ./pipeline_personal_finance/qif_files:${DAGSTER_APP}/pipeline_personal_finance/qif_files
+      - ./grafana/provisioning/dashboards:${DAGSTER_APP}/grafana/provisioning/dashboards:ro
     networks:
       - dagster_network
     # ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       dockerfile: pipeline_personal_finance/dockerfile
       args:
         - DAGSTER_APP=${DAGSTER_APP}
+        - DAGSTER_HOME=${DAGSTER_HOME}
     image: pipeline_personal_finance
     command: ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "pipeline_personal_finance"]
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,6 @@ services:
       dockerfile: pipeline_personal_finance/dockerfile
       args:
         - DAGSTER_APP=${DAGSTER_APP}
-        - DAGSTER_HOME=${DAGSTER_HOME}
     image: pipeline_personal_finance
     command: ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "pipeline_personal_finance"]
     expose:
@@ -99,6 +98,7 @@ services:
     environment:
       TIMEZONE: Australia/Melbourne
       DAGSTER_CURRENT_IMAGE: pipeline_personal_finance
+      DAGSTER_HOME: ${DAGSTER_HOME}
       DAGSTER_POSTGRES_HOST: ${DAGSTER_POSTGRES_HOST}
       DAGSTER_POSTGRES_USER: ${DAGSTER_POSTGRES_USER}
       DAGSTER_POSTGRES_PASSWORD: ${DAGSTER_POSTGRES_PASSWORD}

--- a/pipeline_personal_finance/assets_dashboard_qa.py
+++ b/pipeline_personal_finance/assets_dashboard_qa.py
@@ -73,21 +73,11 @@ def dashboard_quality_gate(context) -> None:
     has_credentials = bool(_GRAFANA_TOKEN or (_GRAFANA_USER and _GRAFANA_PASSWORD))
 
     if not has_credentials:
-        context.log.warning(
-            "Neither GRAFANA_TOKEN nor GRAFANA_ADMIN_PASSWORD is set — "
-            "skipping live panel checks. Add credentials to the container env."
+        raise Failure(
+            "dashboard_quality_gate requires Grafana credentials. "
+            "Set GRAFANA_TOKEN or both GRAFANA_ADMIN_USER and GRAFANA_ADMIN_PASSWORD.",
+            metadata={"grafana_url": MetadataValue.url(_GRAFANA_URL)},
         )
-        _emit_metadata(
-            context,
-            lint_warnings=total_lint_warnings,
-            parse_errors=total_parse_errors,
-            dashboards_checked=0,
-            failing_panels=0,
-            failures=[],
-            live_status="skipped — no credentials",
-            checked_time_windows=[],
-        )
-        return
 
     try:
         client = _checker.GrafanaClient(
@@ -99,21 +89,11 @@ def dashboard_quality_gate(context) -> None:
         datasources = client.datasources()
         dashboards = client.search_dashboards()
     except Exception as exc:
-        context.log.warning(
+        raise Failure(
             f"Cannot reach Grafana at {_GRAFANA_URL}: {exc}. "
-            "Skipping live checks — pipeline data is still valid."
-        )
-        _emit_metadata(
-            context,
-            lint_warnings=total_lint_warnings,
-            parse_errors=total_parse_errors,
-            dashboards_checked=0,
-            failing_panels=0,
-            failures=[],
-            live_status=f"skipped — connection failed: {exc}",
-            checked_time_windows=[],
-        )
-        return
+            "Ensure Grafana is running and GRAFANA_URL is correct.",
+            metadata={"grafana_url": MetadataValue.url(_GRAFANA_URL), "error": str(exc)},
+        ) from exc
 
     try:
         range_days = _checker.parse_time_picker_ranges(_DASHBOARD_TIME_PICKER_RANGES)
@@ -144,7 +124,14 @@ def dashboard_quality_gate(context) -> None:
             )
         except Exception as exc:
             context.log.warning(
-                f"Could not check dashboard '{dash.get('title')}': {exc}. Skipping."
+                f"Could not check dashboard '{dash.get('title')}': {exc}"
+            )
+            all_failures.append(
+                {
+                    "dashboard": dash.get("title", ""),
+                    "panel": "(dashboard-level error)",
+                    "error": f"Check failed: {exc}",
+                }
             )
             continue
         for by_window in check_result.get("by_time_window", []):

--- a/pipeline_personal_finance/docker-entrypoint.sh
+++ b/pipeline_personal_finance/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ -n "${DAGSTER_HOME:-}" ]; then
+  mkdir -p "$DAGSTER_HOME"
+fi
+
+exec "$@"

--- a/pipeline_personal_finance/dockerfile
+++ b/pipeline_personal_finance/dockerfile
@@ -2,7 +2,6 @@
 FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 ARG DAGSTER_APP
-ARG DAGSTER_HOME
 
 ENV YOUR_ENV=${YOUR_ENV} \
   PYTHONFAULTHANDLER=1 \
@@ -16,7 +15,6 @@ ENV YOUR_ENV=${YOUR_ENV} \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
   # Make sure to update it!
-  DAGSTER_HOME=${DAGSTER_HOME:-homenotset} \
   DAGSTER_APP=${DAGSTER_APP:-appnotset} \
   PATH="${DAGSTER_APP}/.venv/bin:$PATH"
 
@@ -30,8 +28,6 @@ COPY grafana grafana
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --package pipeline_personal_finance
-
-RUN mkdir -p ${DAGSTER_HOME}
 
 # Set the working directory to dbt dir to build the script
 WORKDIR ${DAGSTER_APP}/pipeline_personal_finance/dbt_finance
@@ -47,6 +43,8 @@ EXPOSE 4000
 WORKDIR ${DAGSTER_APP}
 
 RUN chmod -R +x ${DAGSTER_APP}
+
+ENTRYPOINT ["./pipeline_personal_finance/docker-entrypoint.sh"]
 
 # Command to run the Dagster gRPC server
 CMD ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "4000", "-m", "pipeline_personal_finance"]

--- a/pipeline_personal_finance/dockerfile
+++ b/pipeline_personal_finance/dockerfile
@@ -2,6 +2,7 @@
 FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 ARG DAGSTER_APP
+ARG DAGSTER_HOME
 
 ENV YOUR_ENV=${YOUR_ENV} \
   PYTHONFAULTHANDLER=1 \
@@ -15,6 +16,7 @@ ENV YOUR_ENV=${YOUR_ENV} \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
   # Make sure to update it!
+  DAGSTER_HOME=${DAGSTER_HOME:-homenotset} \
   DAGSTER_APP=${DAGSTER_APP:-appnotset} \
   PATH="${DAGSTER_APP}/.venv/bin:$PATH"
 
@@ -28,6 +30,8 @@ COPY grafana grafana
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --package pipeline_personal_finance
+
+RUN mkdir -p ${DAGSTER_HOME}
 
 # Set the working directory to dbt dir to build the script
 WORKDIR ${DAGSTER_APP}/pipeline_personal_finance/dbt_finance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.2",
     "sqlfluff>=3.3.0",
     "sqlfluff-templater-dbt>=3.3.0",
 ]

--- a/scripts/check_grafana_dashboards.py
+++ b/scripts/check_grafana_dashboards.py
@@ -424,16 +424,24 @@ def check_dashboard(
         datasource = panel.get("datasource") or {}
         ds_uid = datasource.get("uid")
         if not ds_uid or ds_uid not in datasources:
+            failing_panels.append({
+                "dashboard": dashboard.get("title"),
+                "panel_id": panel.get("id"),
+                "panel_title": panel.get("title"),
+                "messages": f"datasource uid '{ds_uid}' not found in Grafana",
+            })
             continue
 
-        panel_ok = False
+        panel_ok = True
         messages = []
+        has_sql_targets = False
 
         for target in targets:
             raw_sql = target.get("rawSql")
             if not raw_sql:
                 continue
 
+            has_sql_targets = True
             format_hint = target.get("format")
             ref_id = target.get("refId", "A")
 
@@ -456,9 +464,11 @@ def check_dashboard(
                 messages.append(f"{ref_id}: HTTP {exc.response.status_code if exc.response else ''} {detail}")
                 has_data = False
 
-            if has_data:
-                panel_ok = True
-                break
+            if not has_data:
+                panel_ok = False
+
+        if not has_sql_targets:
+            continue
 
         status = {
             "dashboard": dashboard.get("title"),

--- a/scripts/check_grafana_dashboards.py
+++ b/scripts/check_grafana_dashboards.py
@@ -421,18 +421,12 @@ def check_dashboard(
         if not targets:
             continue
 
-        datasource = panel.get("datasource") or {}
-        ds_uid = datasource.get("uid")
-        if not ds_uid or ds_uid not in datasources:
-            failing_panels.append({
-                "dashboard": dashboard.get("title"),
-                "panel_id": panel.get("id"),
-                "panel_title": panel.get("title"),
-                "messages": f"datasource uid '{ds_uid}' not found in Grafana",
-            })
-            continue
+        # Resolve panel-level datasource as a fallback for targets that don't
+        # specify their own.
+        panel_ds = panel.get("datasource") or {}
+        panel_ds_uid = panel_ds.get("uid")
 
-        panel_ok = True
+        any_target_ok = False
         messages = []
         has_sql_targets = False
 
@@ -442,6 +436,16 @@ def check_dashboard(
                 continue
 
             has_sql_targets = True
+
+            # Prefer target-level datasource; fall back to panel-level.
+            target_ds = target.get("datasource") or {}
+            ds_uid = target_ds.get("uid") or panel_ds_uid
+            if not ds_uid or ds_uid not in datasources:
+                messages.append(
+                    f"{target.get('refId', 'A')}: datasource uid '{ds_uid}' not found"
+                )
+                continue
+
             format_hint = target.get("format")
             ref_id = target.get("refId", "A")
 
@@ -464,8 +468,8 @@ def check_dashboard(
                 messages.append(f"{ref_id}: HTTP {exc.response.status_code if exc.response else ''} {detail}")
                 has_data = False
 
-            if not has_data:
-                panel_ok = False
+            if has_data:
+                any_target_ok = True
 
         if not has_sql_targets:
             continue
@@ -477,7 +481,8 @@ def check_dashboard(
             "messages": "; ".join(messages),
         }
 
-        if panel_ok:
+        # Panel passes if at least one SQL target returned data.
+        if any_target_ok:
             ok_panels.append(status)
         else:
             failing_panels.append(status)

--- a/tests/test_dashboard_quality_ranges.py
+++ b/tests/test_dashboard_quality_ranges.py
@@ -66,3 +66,150 @@ def test_dashboard_quick_range_windows_skips_invalid_entries():
     assert checker.dashboard_quick_range_windows(dashboard) == [
         ("quick_range_3", "now-30d", "now")
     ]
+
+
+# ---------------------------------------------------------------------------
+# check_dashboard: target-level datasource resolution and pass semantics
+# ---------------------------------------------------------------------------
+
+class _FakeClient:
+    """Minimal stub for GrafanaClient used in check_dashboard tests."""
+
+    def __init__(self, datasources, query_results=None):
+        self._datasources = datasources
+        self._query_results = query_results or {}
+
+    def datasources(self):
+        return self._datasources
+
+    def dashboard(self, uid):
+        return {}
+
+    def query(self, datasource, raw_sql, **kwargs):
+        ref_id = kwargs.get("ref_id", "A")
+        key = (datasource["uid"], ref_id)
+        if key in self._query_results:
+            return self._query_results[key]
+        # Default: return one row
+        return {
+            "results": {
+                ref_id: {
+                    "frames": [{"data": {"values": [["row1"]]}}]
+                }
+            }
+        }
+
+
+def _make_dashboard(panels):
+    return {"title": "test", "panels": panels, "templating": {"list": []}}
+
+
+def test_check_dashboard_panel_passes_if_any_target_has_data():
+    """Panel with two targets should pass if at least one returns data."""
+    ds = {"pg": {"uid": "pg", "type": "postgres", "id": 1}}
+    # Target A returns data, Target B is empty
+    results = {
+        ("pg", "A"): {"results": {"A": {"frames": [{"data": {"values": [["v"]]}}]}}},
+        ("pg", "B"): {"results": {"B": {"frames": [{"data": {"values": [[]]}}]}}},
+    }
+    client = _FakeClient(ds, results)
+    dashboard = _make_dashboard([
+        {
+            "id": 1,
+            "title": "Mixed",
+            "datasource": {"uid": "pg"},
+            "targets": [
+                {"refId": "A", "rawSql": "SELECT 1"},
+                {"refId": "B", "rawSql": "SELECT 1"},
+            ],
+        }
+    ])
+    ok, fail = checker.check_dashboard(
+        client, {"uid": "x"}, ds,
+        time_from="now-1d", time_to="now", min_rows=1,
+        dashboard_data=dashboard,
+    )
+    assert len(ok) == 1 and len(fail) == 0, "panel should pass when any target has data"
+
+
+def test_check_dashboard_panel_fails_when_all_targets_empty():
+    """Panel should fail only when every target is empty."""
+    ds = {"pg": {"uid": "pg", "type": "postgres", "id": 1}}
+    results = {
+        ("pg", "A"): {"results": {"A": {"frames": [{"data": {"values": [[]]}}]}}},
+        ("pg", "B"): {"results": {"B": {"frames": [{"data": {"values": [[]]}}]}}},
+    }
+    client = _FakeClient(ds, results)
+    dashboard = _make_dashboard([
+        {
+            "id": 1,
+            "title": "AllEmpty",
+            "datasource": {"uid": "pg"},
+            "targets": [
+                {"refId": "A", "rawSql": "SELECT 1"},
+                {"refId": "B", "rawSql": "SELECT 1"},
+            ],
+        }
+    ])
+    ok, fail = checker.check_dashboard(
+        client, {"uid": "x"}, ds,
+        time_from="now-1d", time_to="now", min_rows=1,
+        dashboard_data=dashboard,
+    )
+    assert len(fail) == 1 and len(ok) == 0, "panel should fail when all targets empty"
+
+
+def test_check_dashboard_resolves_target_level_datasource():
+    """Target-level datasource should take precedence over panel-level."""
+    ds = {
+        "pg": {"uid": "pg", "type": "postgres", "id": 1},
+        "duck": {"uid": "duck", "type": "duckdb", "id": 2},
+    }
+    # Only the duckdb datasource returns data
+    results = {
+        ("pg", "A"): {"results": {"A": {"frames": [{"data": {"values": [[]]}}]}}},
+        ("duck", "B"): {"results": {"B": {"frames": [{"data": {"values": [["v"]]}}]}}},
+    }
+    client = _FakeClient(ds, results)
+    dashboard = _make_dashboard([
+        {
+            "id": 1,
+            "title": "TargetDS",
+            "datasource": {"uid": "pg"},
+            "targets": [
+                {"refId": "A", "rawSql": "SELECT 1"},
+                {"refId": "B", "rawSql": "SELECT 1", "datasource": {"uid": "duck"}},
+            ],
+        }
+    ])
+    ok, fail = checker.check_dashboard(
+        client, {"uid": "x"}, ds,
+        time_from="now-1d", time_to="now", min_rows=1,
+        dashboard_data=dashboard,
+    )
+    # Target B used duckdb and returned data, so panel passes
+    assert len(ok) == 1 and len(fail) == 0
+
+
+def test_check_dashboard_missing_ds_does_not_block_other_targets():
+    """A target with an unknown datasource should not fail the whole panel
+    if another target succeeds."""
+    ds = {"pg": {"uid": "pg", "type": "postgres", "id": 1}}
+    client = _FakeClient(ds)
+    dashboard = _make_dashboard([
+        {
+            "id": 1,
+            "title": "MixedDS",
+            "datasource": {"uid": "pg"},
+            "targets": [
+                {"refId": "A", "rawSql": "SELECT 1"},
+                {"refId": "B", "rawSql": "SELECT 1", "datasource": {"uid": "gone"}},
+            ],
+        }
+    ])
+    ok, fail = checker.check_dashboard(
+        client, {"uid": "x"}, ds,
+        time_from="now-1d", time_to="now", min_rows=1,
+        dashboard_data=dashboard,
+    )
+    assert len(ok) == 1, "panel should pass — target A succeeded"

--- a/uv.lock
+++ b/uv.lock
@@ -2256,6 +2256,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "sqlfluff" },
     { name = "sqlfluff-templater-dbt" },
 ]
@@ -2270,6 +2271,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "sqlfluff", specifier = ">=3.3.0" },
     { name = "sqlfluff-templater-dbt", specifier = ">=3.3.0" },
 ]


### PR DESCRIPTION
## Summary
- hard-fail the dashboard quality gate when Grafana credentials are missing or Grafana is unreachable
- record dashboard-level checker errors as gate failures instead of silently skipping those dashboards
- wire `DASHBOARD_QUALITY_WARN_ONLY` through Dagster launched runs so the new warn-only escape hatch actually works
- resolve datasources per target with panel-level fallback, and only fail a panel when all SQL targets are empty or error
- normalize mounted dashboard/script paths to `${DAGSTER_APP}` so the runtime paths match the container layout
- create the configured `DAGSTER_HOME` inside the pipeline image so direct `dagster job execute` works in the container
- add regression tests for time-window helpers and `check_dashboard()` datasource/pass semantics
- declare `pytest` in the root dev dependency group for reproducible local test setup

## Test plan
- [x] `source .venv/bin/activate && pytest -q tests/test_dashboard_quality_ranges.py`
- [x] `docker compose config`
- [x] `source .venv/bin/activate && dbt deps --project-dir pipeline_personal_finance/dbt_finance`
- [x] `docker-compose -f docker-compose.yml -f docker-compose.local.yml up -d --build pipeline_personal_finance dagster_webserver dagster_daemon`
- [x] `docker-compose -f docker-compose.yml -f docker-compose.local.yml exec -T pipeline_personal_finance dagster job execute -m pipeline_personal_finance -j qif_pipeline_job` (starts successfully after the `DAGSTER_HOME` fix; run stops at the existing `dashboard_time_control_policy_gate`)
- [x] `docker-compose -f docker-compose.yml -f docker-compose.local.yml exec -T -e DASHBOARD_POLICY_GATE_WARN_ONLY=true pipeline_personal_finance dagster job execute -m pipeline_personal_finance -j qif_pipeline_job` (reaches `dashboard_quality_gate`; run fails there with `23 dashboards checked, 96 failing panels`)

## Notes
- Repo-wide `pytest` still has unrelated pre-existing failures in `pipeline_personal_finance/test_resources.py` and `tests/test_task_110_time_control_policy.py`.
- The default-mode pipeline failure is a pre-existing dashboard time-control policy issue, not a regression from this branch.
- The warn-only pipeline run confirms the strict dashboard quality gate is reachable under the normal container startup path and is now blocking on real empty-panel findings.
