### PR TITLE
feat: add last completed month messaging to dashboards

### DIFF
--- a/grafana/provisioning/dashboards/account-performance-dashboard.json
+++ b/grafana/provisioning/dashboards/account-performance-dashboard.json
@@ -27,10 +27,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/amazon-spending-dashboard.json
+++ b/grafana/provisioning/dashboards/amazon-spending-dashboard.json
@@ -27,6 +27,70 @@
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -53,7 +117,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 1,
       "options": {
@@ -138,7 +202,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 0
+        "y": 4
       },
       "id": 10,
       "options": {
@@ -201,7 +265,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 0
+        "y": 4
       },
       "id": 9,
       "options": {
@@ -265,7 +329,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 0
+        "y": 4
       },
       "id": 10,
       "options": {
@@ -329,7 +393,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 4
       },
       "id": 2,
       "options": {
@@ -439,7 +503,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 12
       },
       "id": 3,
       "options": {
@@ -527,7 +591,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 12
       },
       "id": 11,
       "options": {
@@ -583,7 +647,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 12
       },
       "id": 4,
       "options": {
@@ -723,7 +787,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 20
       },
       "id": 5,
       "options": {
@@ -778,7 +842,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 28
       },
       "id": 6,
       "options": {
@@ -848,7 +912,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 28
       },
       "id": 7,
       "options": {
@@ -940,7 +1004,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 36
       },
       "id": 8,
       "options": {
@@ -1000,7 +1064,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 44
       },
       "id": 11,
       "options": {
@@ -1059,7 +1123,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 52
       },
       "id": 12,
       "options": {

--- a/grafana/provisioning/dashboards/category-spending-dashboard.json
+++ b/grafana/provisioning/dashboards/category-spending-dashboard.json
@@ -37,10 +37,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/expense-performance-dashboard.json
+++ b/grafana/provisioning/dashboards/expense-performance-dashboard.json
@@ -27,10 +27,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 6,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/financial-projections-dashboard.json
+++ b/grafana/provisioning/dashboards/financial-projections-dashboard.json
@@ -24,6 +24,70 @@
   "panels": [
     {
       "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
         "type": "text"
       },
       "fieldConfig": {
@@ -32,8 +96,8 @@
       },
       "gridPos": {
         "h": 22,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/four-year-financial-comparison-dashboard.json
+++ b/grafana/provisioning/dashboards/four-year-financial-comparison-dashboard.json
@@ -27,10 +27,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 6,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/grocery-spending-dashboard.json
+++ b/grafana/provisioning/dashboards/grocery-spending-dashboard.json
@@ -27,6 +27,70 @@
         "type": "postgres",
         "uid": "PCC52D03280B7034C"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "PCC52D03280B7034C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "PCC52D03280B7034C"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -114,7 +178,7 @@
         "h": 10,
         "w": 8,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 1,
       "options": {
@@ -182,7 +246,7 @@
         "h": 10,
         "w": 8,
         "x": 8,
-        "y": 0
+        "y": 4
       },
       "id": 10,
       "options": {
@@ -254,7 +318,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 0
+        "y": 4
       },
       "id": 4,
       "options": {
@@ -383,7 +447,7 @@
         "h": 10,
         "w": 8,
         "x": 16,
-        "y": 0
+        "y": 4
       },
       "id": 5,
       "options": {
@@ -520,7 +584,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 14
       },
       "id": 2,
       "options": {
@@ -657,7 +721,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 25
       },
       "id": 3,
       "options": {
@@ -794,7 +858,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 36
       },
       "id": 6,
       "options": {
@@ -933,7 +997,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 47
       },
       "id": 7,
       "options": {
@@ -991,7 +1055,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 54
+        "y": 58
       },
       "id": 8,
       "options": {
@@ -1066,7 +1130,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 54
+        "y": 58
       },
       "id": 9,
       "options": {
@@ -1124,7 +1188,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 68
       },
       "id": 11,
       "options": {
@@ -1218,7 +1282,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 68
       },
       "id": 12,
       "options": {
@@ -1309,7 +1373,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 76
       },
       "id": 13,
       "options": {
@@ -1455,7 +1519,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 84
       },
       "id": 14,
       "options": {
@@ -1577,7 +1641,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 94
       },
       "id": 15,
       "options": {
@@ -1688,7 +1752,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 104
       },
       "id": 16,
       "options": {

--- a/grafana/provisioning/dashboards/outflows-insights-dashboard.json
+++ b/grafana/provisioning/dashboards/outflows-insights-dashboard.json
@@ -27,10 +27,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 907,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 63,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/outflows-reconciliation-dashboard.json
+++ b/grafana/provisioning/dashboards/outflows-reconciliation-dashboard.json
@@ -46,10 +46,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 4,
-        "w": 24,
+        "w": 6,
         "x": 0,
+        "y": 0
+      },
+      "id": 306,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/transaction-analysis-dashboard.json
+++ b/grafana/provisioning/dashboards/transaction-analysis-dashboard.json
@@ -64,10 +64,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 909,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 12,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/grafana/provisioning/dashboards/year-over-year-comparison-dashboard.json
+++ b/grafana/provisioning/dashboards/year-over-year-comparison-dashboard.json
@@ -27,10 +27,74 @@
         "type": "text",
         "uid": "-- Text --"
       },
+      "description": "The most recent fully closed month available across the shared reporting layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "string"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/Last Completed Month/",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "text",
+            "uid": "-- Text --"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT TO_CHAR(MAX(TO_DATE(budget_year_month || '-01', 'YYYY-MM-DD')), 'Mon YYYY') AS \"Last Completed Month\"\nFROM reporting.rpt_monthly_budget_summary\nWHERE budget_year_month < TO_CHAR(CURRENT_DATE, 'YYYY-MM');",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Completed Month",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "text",
+        "uid": "-- Text --"
+      },
       "gridPos": {
         "h": 12,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 0
       },
       "id": 100,

--- a/tests/test_dashboard_last_completed_month_message.py
+++ b/tests/test_dashboard_last_completed_month_message.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_DIR = REPO_ROOT / "grafana" / "provisioning" / "dashboards"
+RECENCY_PANEL_TITLES = {"Data Freshness", "Last Completed Month"}
+
+
+def test_every_dashboard_has_last_completed_month_message():
+    dashboard_files = sorted(DASHBOARD_DIR.glob("*.json"))
+    assert dashboard_files, "Expected provisioned Grafana dashboards to be present."
+
+    missing = []
+
+    for dashboard_file in dashboard_files:
+        dashboard = json.loads(dashboard_file.read_text(encoding="utf-8"))
+        panel_titles = {
+            panel.get("title")
+            for panel in dashboard.get("panels", [])
+            if isinstance(panel, dict)
+        }
+        if RECENCY_PANEL_TITLES.isdisjoint(panel_titles):
+            missing.append(dashboard_file.name)
+
+    assert not missing, (
+        "Dashboards missing last-completed-month messaging: "
+        + ", ".join(missing)
+    )


### PR DESCRIPTION
## Summary
- add a live \Last Completed Month\ stat to dashboards that did not already surface recency messaging
- source the month from \eporting.rpt_monthly_budget_summary\ so dashboard messaging stays consistent with the reporting layer
- add a regression test to ensure every provisioned dashboard keeps either \Data Freshness\ or \Last Completed Month\

## Testing
- \python scripts/validate_dashboard_json.py\
- \pytest tests/test_dashboard_last_completed_month_message.py tests/test_dashboard_panel_fit.py\
