### PR TITLE
fix: retire legacy project containers on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
-.PHONY: help setup up down logs clean restart rebuild lint lint-fix test dagster-ui grafana-ui status dagster-run dbt-deps dbt-compile dbt-build dbt-test bootstrap-local-seeds bootstrap-worktree
+.PHONY: help setup up down logs clean restart rebuild lint lint-fix test dagster-ui grafana-ui status dagster-run dbt-deps dbt-compile dbt-build dbt-test bootstrap-local-seeds bootstrap-worktree retire-legacy
 
 WORKTREE_ENV_FILE = .env.worktree.auto
 PYTHON ?= python
 COMPOSE_PROJECT_NAME := $(shell $(PYTHON) scripts/write_worktree_compose_env.py --print-project-name)
 COMPOSE = docker compose --project-name $(COMPOSE_PROJECT_NAME) --env-file .env --env-file $(WORKTREE_ENV_FILE) -f docker-compose.yml
 
+# Legacy project name (underscores) predates worktree port isolation.
+# Stop those containers so they don't hold ports the new project needs.
+LEGACY_PROJECT_NAME = qif_personal_finance
+
 compose-env:
 	@$(PYTHON) scripts/write_worktree_compose_env.py --output $(WORKTREE_ENV_FILE)
+
+retire-legacy:
+	@if docker compose --project-name $(LEGACY_PROJECT_NAME) ps -q 2>/dev/null | grep -q .; then \
+		echo "Stopping legacy containers (project: $(LEGACY_PROJECT_NAME))..."; \
+		docker compose --project-name $(LEGACY_PROJECT_NAME) down; \
+	fi
 
 bootstrap-local-seeds:
 	@$(PYTHON) scripts/bootstrap_local_seeds.py
@@ -48,7 +58,7 @@ setup:
 	fi
 
 # Start services
-up: compose-env
+up: compose-env retire-legacy
 	@if [ ! -f .env ]; then \
 		cp .env.template .env; \
 		echo "WARNING: .env not found — created from .env.template with placeholder values."; \
@@ -83,7 +93,7 @@ logs:
 	$(COMPOSE) logs -f
 
 # Clean up
-clean:
+clean: retire-legacy
 	@$(MAKE) compose-env
 	$(COMPOSE) down -v --remove-orphans
 	docker system prune -f
@@ -94,7 +104,7 @@ restart:
 	$(COMPOSE) restart
 
 # Rebuild and restart
-rebuild: compose-env
+rebuild: compose-env retire-legacy
 	$(COMPOSE) down
 	$(COMPOSE) build --no-cache
 	$(COMPOSE) up -d


### PR DESCRIPTION
## Summary
- Adds a `retire-legacy` Makefile target that detects running containers from the old `qif_personal_finance` project name (underscores) and stops them
- Wires `retire-legacy` into `up`, `rebuild`, and `clean` targets so port conflicts are automatically resolved
- Fixes the `bind: Only one usage of each socket address` error when Grafana (port 3001) from the legacy project blocks the new `qif-personal-finance` project

## Context
The worktree port isolation feature (merged in `6b036cb`) introduced the canonical project name `qif-personal-finance` (hyphens). Environments that previously ran with Docker Compose's default project name `qif_personal_finance` (underscores) still have those containers running, causing port 3001 conflicts on `make up` / `make rebuild`.

## Test plan
- [ ] Run `make up` on a machine with legacy `qif_personal_finance` containers still running — should auto-stop them and start cleanly
- [ ] Run `make up` on a clean machine (no legacy containers) — should be a no-op with no errors
- [ ] Verify `make retire-legacy` works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)