### PR TITLE
fix: retire legacy project containers via Python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup up down logs clean restart rebuild lint lint-fix test dagster-ui grafana-ui status dagster-run dbt-deps dbt-compile dbt-build dbt-test bootstrap-local-seeds bootstrap-worktree
+.PHONY: help setup up down logs clean restart rebuild lint lint-fix test dagster-ui grafana-ui status dagster-run dbt-deps dbt-compile dbt-build dbt-test bootstrap-local-seeds bootstrap-worktree retire-legacy
 
 WORKTREE_ENV_FILE = .env.worktree.auto
 PYTHON ?= python
@@ -7,6 +7,9 @@ COMPOSE = docker compose --project-name $(COMPOSE_PROJECT_NAME) --env-file .env 
 
 compose-env:
 	@$(PYTHON) scripts/write_worktree_compose_env.py --output $(WORKTREE_ENV_FILE)
+
+retire-legacy:
+	@$(PYTHON) scripts/retire_legacy_project.py
 
 bootstrap-local-seeds:
 	@$(PYTHON) scripts/bootstrap_local_seeds.py
@@ -48,7 +51,7 @@ setup:
 	fi
 
 # Start services
-up: compose-env
+up: compose-env retire-legacy
 	@if [ ! -f .env ]; then \
 		cp .env.template .env; \
 		echo "WARNING: .env not found — created from .env.template with placeholder values."; \
@@ -83,7 +86,7 @@ logs:
 	$(COMPOSE) logs -f
 
 # Clean up
-clean:
+clean: retire-legacy
 	@$(MAKE) compose-env
 	$(COMPOSE) down -v --remove-orphans
 	docker system prune -f
@@ -94,7 +97,7 @@ restart:
 	$(COMPOSE) restart
 
 # Rebuild and restart
-rebuild: compose-env
+rebuild: compose-env retire-legacy
 	$(COMPOSE) down
 	$(COMPOSE) build --no-cache
 	$(COMPOSE) up -d

--- a/scripts/retire_legacy_project.py
+++ b/scripts/retire_legacy_project.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Stop containers from the legacy project name (qif_personal_finance).
+
+The old underscore-based project name predates the worktree port-isolation
+feature.  Containers left running under that name hold the same host ports
+the new qif-personal-finance project needs, causing bind failures.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+LEGACY_PROJECT_NAME = "qif_personal_finance"
+
+
+def main() -> int:
+    result = subprocess.run(
+        ["docker", "compose", "--project-name", LEGACY_PROJECT_NAME, "ps", "-q"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return 0
+
+    print(f"Stopping legacy containers (project: {LEGACY_PROJECT_NAME})...")
+    subprocess.run(
+        ["docker", "compose", "--project-name", LEGACY_PROJECT_NAME, "down"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/retire_legacy_project.py` to detect and stop containers from the old `qif_personal_finance` project name (underscores)
- Wires `retire-legacy` target into `up`, `rebuild`, and `clean` so port conflicts are automatically resolved
- Uses Python instead of shell syntax for Windows compatibility (GNU Make 3.81 falls back to cmd.exe)

## Context
Replaces the reverted PR #100 which used bash syntax that broke on Windows.

## Test plan
- [ ] `make up` on machine with legacy containers — auto-stops them and starts cleanly
- [ ] `make up` on clean machine — no-op, no errors
- [ ] `make retire-legacy` works standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)