### PR TITLE
Fix dbt seed CSV parsing and dim_categories duplicate key

### DIFF
--- a/pipeline_personal_finance/dbt_finance/models/marts/dim_categories.sql
+++ b/pipeline_personal_finance/dbt_finance/models/marts/dim_categories.sql
@@ -9,13 +9,14 @@
 }}
 
 WITH unique_categories AS (
-  SELECT DISTINCT
+  SELECT
     category,
     subcategory,
     store,
     internal_indicator,
-    payment_frequency
+    MAX(NULLIF(payment_frequency, '')) AS payment_frequency
   FROM {{ ref('banking_categories') }}
+  GROUP BY category, subcategory, store, internal_indicator
 ),
 
 category_hierarchy AS (

--- a/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
+++ b/pipeline_personal_finance/dbt_finance/seeds/banking_categories.csv
@@ -278,5 +278,5 @@ GOOGLE SPO,,,,,Household & Services,Subscription,Google,External,monthly
 Dr Clare Schofield,,,,,Health & Beauty,Medical,Dr Clare Schofield,External,
 Grandma              - Philip Patterson,,,,,Bank Transaction,Gift,Grandma,External,
 MY SLICE OF LIFE,,,,,Leisure,Course,Pasta Making Course,External,
-WRIGHT, ANNALIESE,,,,,Health & Beauty,Medical,Annaliese Wright,External,
+"WRIGHT, ANNALIESE",,,,,Health & Beauty,Medical,Annaliese Wright,External,
 CUBBI BUDDI,,,,,Family & Kids,Toys,Cubbi Buddi,External,


### PR DESCRIPTION
## Summary
- **banking_categories.csv**: Quoted `WRIGHT, ANNALIESE` to fix unquoted comma that gave dbt 11 columns instead of 10, failing the entire pipeline at seed loading
- **dim_categories.sql**: Changed `SELECT DISTINCT` to `GROUP BY` on the 4 surrogate key fields to eliminate duplicate `category_key` violations caused by rows sharing the same key but differing on `payment_frequency`

## Test plan
- [x] Verified CSV parses correctly with Python csv module (0 column-count mismatches)
- [x] Rebuilt pipeline container and ran `qif_pipeline_job` — dbt build passes (seeds, models, tests all OK)
- [x] Confirmed remaining failures are pre-existing QA gate issues (empty Recommendation Tracker panel), not related to these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)