### PR TITLE
Add coles shopper Dagster code location

### DIFF
--- a/dagster_core/workspace.yaml
+++ b/dagster_core/workspace.yaml
@@ -4,6 +4,10 @@ load_from:
       host: pipeline_personal_finance
       port: 4000
       location_name: "pipeline_personal_finance"
+  - grpc_server:
+      host: coles-shopper
+      port: 4000
+      location_name: "coles_llm_shopper"
   # - server:
   #     host: pipeline_y
   #     port: 4047


### PR DESCRIPTION
## Summary
- register the `coles-shopper` gRPC code location in `dagster_core/workspace.yaml`
- expose the location to the existing Dagster deployment as `coles_llm_shopper`

## Validation
- verified the `coles-llm-shopper` service starts on `qif_personal_finance_dagster_network`
- confirmed the service advertises the `coles-shopper` hostname on port `4000`, matching this workspace entry
- ran `uv run pytest -q` in `coles-llm-shopper` after the Dagster deployment fixes (`136 passed`)

## Notes
- this PR only updates the existing Dagster workspace; the deployment wiring changes live in the linked `coles-llm-shopper` PR branch