### PR TITLE
feat: add Coles shopper code location with volume and startup fixes

### DIFF
--- a/coles-auth.sh
+++ b/coles-auth.sh
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
 set -e
-docker run -it --rm -p 5900:5900 -v coles-llm-shopper_coles_data:/app/data coles-shopper bash -c 'apt-get install -y -q x11vnc 2>/dev/null; Xvfb :99 -screen 0 1280x1024x24 & sleep 2; x11vnc -display :99 -nopw -listen 0.0.0.0 -rfbport 5900 -forever -quiet & sleep 2; DISPLAY=:99 PLAYWRIGHT_HEADED=1 coles-shopper auth --state /app/data/state/coles_state.json'
+
+if [[ -z "${VNC_PASSWORD:-}" ]]; then
+  echo "Set VNC_PASSWORD before running this helper." >&2
+  echo "Connect via localhost:5900, or use an SSH tunnel if running remotely." >&2
+  exit 1
+fi
+
+docker run -it --rm \
+  -p 127.0.0.1:5900:5900 \
+  -e VNC_PASSWORD \
+  -v coles-llm-shopper_coles_data:/app/data \
+  coles-shopper bash -c 'apt-get install -y -q x11vnc 2>/dev/null; Xvfb :99 -screen 0 1280x1024x24 & sleep 2; x11vnc -storepasswd "$VNC_PASSWORD" /tmp/x11vnc.pass >/dev/null; x11vnc -display :99 -rfbauth /tmp/x11vnc.pass -listen 127.0.0.1 -rfbport 5900 -forever -quiet & sleep 2; DISPLAY=:99 PLAYWRIGHT_HEADED=1 coles-shopper auth --state /app/data/state/coles_state.json'

--- a/coles-auth.sh
+++ b/coles-auth.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+docker run -it --rm -p 5900:5900 -v coles-llm-shopper_coles_data:/app/data coles-shopper bash -c 'apt-get install -y -q x11vnc 2>/dev/null; Xvfb :99 -screen 0 1280x1024x24 & sleep 2; x11vnc -display :99 -nopw -listen 0.0.0.0 -rfbport 5900 -forever -quiet & sleep 2; DISPLAY=:99 PLAYWRIGHT_HEADED=1 coles-shopper auth --state /app/data/state/coles_state.json'

--- a/dagster_core/dagster.yaml
+++ b/dagster_core/dagster.yaml
@@ -45,6 +45,9 @@ run_launcher:
       - ANTHROPIC_API_KEY
       - USE_NIX_DEVSHELL
       - PLAYWRIGHT_HEADED
+      - HA_URL
+      - HA_TOKEN
+      - HA_NOTIFY_SERVICE
     network:
       env: DAGSTER_NETWORK
     container_kwargs:

--- a/dagster_core/dagster.yaml
+++ b/dagster_core/dagster.yaml
@@ -35,6 +35,16 @@ run_launcher:
       - DBT_EXECUTION_CONTEXT
       - DASHBOARD_POLICY_GATE_WARN_ONLY
       - DASHBOARD_QUALITY_WARN_ONLY
+      - COLES_STATE_PATH
+      - KEEP_SYNC_ENABLED
+      - GOOGLE_KEEP_TOKEN_PATH
+      - GOOGLE_KEEP_LIST_NAME
+      - GOOGLE_KEEP_EMAIL
+      - KEEP_AUTO_ADD_MIN_CONFIDENCE
+      - KEEP_DELETE_ON_ADD
+      - ANTHROPIC_API_KEY
+      - USE_NIX_DEVSHELL
+      - PLAYWRIGHT_HEADED
     network:
       env: DAGSTER_NETWORK
     container_kwargs:
@@ -42,6 +52,9 @@ run_launcher:
         - /var/run/docker.sock:/var/run/docker.sock
         - /tmp/io_manager_storage:/tmp/io_manager_storage
         - /tmp/dagster-data:/opt/dagster/dagster_home/storage
+        # coles-llm-shopper run workers need this volume to read coles_state.json
+        # and keep_token.json at runtime.
+        - coles-llm-shopper_coles_data:/app/data
 
 run_storage:
   module: dagster_postgres.run_storage

--- a/import-keep-token.sh
+++ b/import-keep-token.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VOLUME_NAME="${COLES_DATA_VOLUME:-coles-llm-shopper_coles_data}"
+TOKEN_PATH="/app/data/state/keep_token.json"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required but was not found on PATH." >&2
+  exit 1
+fi
+
+cat >&2 <<'MSG'
+Paste the full keep_token.json content, then press Ctrl+D.
+
+The JSON must include:
+  - email
+  - master_token
+
+MSG
+
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+cat > "$tmp_file"
+
+python3 - "$tmp_file" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    data = json.loads(path.read_text(encoding="utf-8"))
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid JSON: {exc}") from exc
+
+missing = [key for key in ("email", "master_token") if not data.get(key)]
+if missing:
+    raise SystemExit(f"Missing required key(s): {', '.join(missing)}")
+
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+print(f"Token JSON validated for {data['email']}", file=sys.stderr)
+PY
+
+docker run --rm -i \
+  -v "${VOLUME_NAME}:/app/data" \
+  alpine sh -c "mkdir -p /app/data/state && cat > '${TOKEN_PATH}' && chmod 600 '${TOKEN_PATH}'" \
+  < "$tmp_file"
+
+docker run --rm \
+  -v "${VOLUME_NAME}:/app/data" \
+  alpine sh -c "test -s '${TOKEN_PATH}' && ls -l '${TOKEN_PATH}'"
+
+echo "Imported Keep token into Docker volume ${VOLUME_NAME}:${TOKEN_PATH}" >&2

--- a/pipeline_personal_finance/__init__.py
+++ b/pipeline_personal_finance/__init__.py
@@ -19,4 +19,10 @@ def __getattr__(name: str):
     raise AttributeError(name)
 
 
+def __dir__():
+    # Expose lazy attributes so inspect.getmembers() (used by Dagster's
+    # autodiscovery) includes them when enumerating module members.
+    return list(globals().keys()) + ["defs", "dbt_manifest_path"]
+
+
 __all__ = ["defs", "dbt_manifest_path"]

--- a/scripts/write_worktree_compose_env.py
+++ b/scripts/write_worktree_compose_env.py
@@ -45,21 +45,47 @@ def slugify(value: str) -> str:
     return "".join(chars).strip("-") or "worktree"
 
 
+BIND_HOST_KEYS = {"DAGSTER_UI_BIND_HOST", "GRAFANA_BIND_HOST", "POSTGRES_BIND_HOST"}
+
+
+def _read_env_file(repo_root: Path) -> dict[str, str]:
+    """Read key=value pairs from .env in repo_root, ignoring comments."""
+    env_path = repo_root / ".env"
+    result: dict[str, str] = {}
+    if not env_path.exists():
+        return result
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
 def derive_values(repo_root: Path) -> dict[str, str]:
     worktree_name = repo_root.name
+    env_overrides = _read_env_file(repo_root)
+
     if worktree_name in MAIN_NAMES:
-        return DEFAULTS.copy()
+        values = DEFAULTS.copy()
+    else:
+        digest = hashlib.sha1(str(repo_root).encode("utf-8")).hexdigest()
+        offset = int(digest[:8], 16) % PORT_RANGE
+        project_name = f"qif-{slugify(worktree_name)}"
 
-    digest = hashlib.sha1(str(repo_root).encode("utf-8")).hexdigest()
-    offset = int(digest[:8], 16) % PORT_RANGE
-    project_name = f"qif-{slugify(worktree_name)}"
+        values = DEFAULTS.copy()
+        values["COMPOSE_PROJECT_NAME"] = project_name
+        for key, base in PORT_BASES.items():
+            values[key] = str(base + offset)
+        # Each worktree gets its own image tag so builds don't overwrite each other.
+        values["PIPELINE_IMAGE"] = f"pipeline_personal_finance-{slugify(worktree_name)}"
 
-    values = DEFAULTS.copy()
-    values["COMPOSE_PROJECT_NAME"] = project_name
-    for key, base in PORT_BASES.items():
-        values[key] = str(base + offset)
-    # Each worktree gets its own image tag so builds don't overwrite each other.
-    values["PIPELINE_IMAGE"] = f"pipeline_personal_finance-{slugify(worktree_name)}"
+    # Allow .env to override bind hosts (e.g. 0.0.0.0 for LAN access).
+    for key in BIND_HOST_KEYS:
+        if key in env_overrides:
+            values[key] = env_overrides[key]
+
     return values
 
 


### PR DESCRIPTION
## Summary
- Register `coles_llm_shopper` as a Dagster code location via `workspace.yaml`
- Fix `pipeline_personal_finance` startup failure caused by Dagster 1.12 autodiscovery using `inspect.getmembers()` (which calls `dir()`) — lazy `__getattr__`-based `defs` was invisible; fixed by adding `__dir__()` to the module
- Update `dagster_core/dagster.yaml` to mount `coles-llm-shopper_coles_data` volume and pass coles/keep env vars to run workers via `DockerRunLauncher`
- Add `write_worktree_compose_env.py` fix to respect `DAGSTER_UI_BIND_HOST`/`GRAFANA_BIND_HOST` from `.env` so the server is reachable on LAN
- Add `coles-auth.sh` helper for VNC-based Coles session bootstrapping on headless servers

## Test plan
- [x] All 5 containers healthy after `make rebuild`
- [x] Both code locations visible in Dagster UI (`pipeline_personal_finance`, `coles_llm_shopper`)
- [x] `buy_again_job` runs to SUCCESS — 48 products fetched and cached
- [x] `coles_state.json` accessible from named volume in run workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)