### PR TITLE
fix: use proper logger pattern in constants.py

### DIFF
--- a/pipeline_personal_finance/constants.py
+++ b/pipeline_personal_finance/constants.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from dagster_dbt import DbtCliResource
 
+_logger = logging.getLogger(__name__)
+
 # Keep dbt resolution pinned to the dbt project directory itself.
 DBT_PROJECT_DIR = Path(__file__).resolve().parent / "dbt_finance"
 DBT_TARGET_DIR = DBT_PROJECT_DIR / "target"
@@ -19,12 +21,10 @@ PRIVATE_SEED_NAMES = (
     "recommendation_outcomes",
 )
 
-# Log the DBT_PROJECT_DIR when the application starts or when it's used
-logging.info(f"DBT_PROJECT_DIR set to: {DBT_PROJECT_DIR}")
-
 
 def ensure_private_seed_stubs() -> None:
     """Materialize header-only private seed stubs before dbt parses refs."""
+    _logger.debug("DBT_PROJECT_DIR set to: %s", DBT_PROJECT_DIR)
     SEED_DIR.mkdir(parents=True, exist_ok=True)
     for seed_name in PRIVATE_SEED_NAMES:
         target = SEED_DIR / f"{seed_name}.csv"


### PR DESCRIPTION
## Summary
- Fixed logging antipattern in `constants.py` where `logging.info()` was called at module import time
- This caused the message to be silently dropped or trigger a "No handlers found" warning since logging wasn't configured yet
- Now uses `logging.getLogger(__name__)` to create a proper module-level logger
- Moved the log call into `ensure_private_seed_stubs()` where it runs during initialization
- Changed log level from `info` to `debug` as this is diagnostic information

## Test plan
- [x] Code review confirms the change follows Python logging best practices
- [x] No functional changes - just fixes the logging pattern
- [ ] Run existing tests to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)