### PR TITLE
Remove useless try/except block in resources.py

### DIFF
--- a/pipeline_personal_finance/resources.py
+++ b/pipeline_personal_finance/resources.py
@@ -43,18 +43,15 @@ class SqlAlchemyClientResource(ConfigurableResource):
         check_db_sql = "SELECT current_database();"
 
         with self.get_connection() as conn:
-            try:
-                # Check the current database name
-                result = conn.execute(sqlalchemy.text(check_db_sql)).fetchone()
-                current_db = result[0] if result else "Unknown"
+            # Check the current database name
+            result = conn.execute(sqlalchemy.text(check_db_sql)).fetchone()
+            current_db = result[0] if result else "Unknown"
 
-                conn.execute(sqlalchemy.text(create_schema_sql))
-                conn.commit()  # Commit the schema creation
+            conn.execute(sqlalchemy.text(create_schema_sql))
+            conn.commit()  # Commit the schema creation
 
-                result = conn.execute(sqlalchemy.text(verify_schema_sql)).fetchone()
-                if not result:
-                    raise RuntimeError(
-                        f"Failed to create or verify the existence of schema '{schema}'."
-                    )
-            except Exception as e:
-                raise
+            result = conn.execute(sqlalchemy.text(verify_schema_sql)).fetchone()
+            if not result:
+                raise RuntimeError(
+                    f"Failed to create or verify the existence of schema '{schema}'."
+                )


### PR DESCRIPTION
## Summary
Automated code quality improvement: removed a useless try/except block that provided no value.

## Changes
- **File:** `pipeline_personal_finance/resources.py` (lines 45-57)
- **Change:** Removed `try/except Exception: raise` wrapper that caught exceptions only to re-raise them immediately

## Before
```python
with self.get_connection() as conn:
    try:
        # ... database operations ...
    except Exception as e:
        raise
```

## After
```python
with self.get_connection() as conn:
    # ... database operations ...
```

## Why This Matters
1. **Removes anti-pattern** - Catching and re-raising without added value is a Python anti-pattern
2. **Improves readability** - Reduces unnecessary indentation
3. **Eliminates dead code** - The exception variable `e` was never used
4. **Zero risk** - Behavior is identical; exceptions still propagate naturally
5. **Linter-friendly** - Many tools flag unused exception variables

## Testing
- ✓ Python syntax validation passed
- ✓ No functional changes; exception handling behavior unchanged

🤖 Generated via automated overnight repository improvement