### PR TITLE
fix: fall back to default for non-positive QIF run timeouts

### DIFF
--- a/pipeline_personal_finance/run_timeout.py
+++ b/pipeline_personal_finance/run_timeout.py
@@ -11,9 +11,14 @@ def parse_timeout_hours(raw_value: str | None, default: float = 2.0) -> float:
     if not value:
         return default
     try:
-        return max(float(value), 0.0)
+        parsed = float(value)
     except ValueError:
         return default
+    # A non-positive timeout would mark every in-flight run as stale on the
+    # next sensor tick, so fall back to the default instead of returning 0.
+    if parsed <= 0:
+        return default
+    return parsed
 
 
 def run_status_name(run) -> str:

--- a/tests/test_reporting_data_quality_checks.py
+++ b/tests/test_reporting_data_quality_checks.py
@@ -289,3 +289,8 @@ def test_timeout_helpers_identify_stale_runs():
     assert stale[0][0] == "stale"
     assert run_timeout.parse_timeout_hours("  ") == 2.0
     assert run_timeout.parse_timeout_hours("4.5") == 4.5
+    # Non-positive timeouts must fall back to the default to avoid
+    # terminating every in-flight run on the next sensor tick.
+    assert run_timeout.parse_timeout_hours("0") == 2.0
+    assert run_timeout.parse_timeout_hours("-3") == 2.0
+    assert run_timeout.parse_timeout_hours("0", default=1.5) == 1.5


### PR DESCRIPTION
## Summary
- `parse_timeout_hours` previously clamped any non-positive parsed value to `0.0` via `max(float(value), 0.0)`. Setting `QIF_DAGSTER_RUN_TIMEOUT_HOURS=0` (or any negative value) made `find_stale_runs` use a cutoff equal to `now`, so every in-flight `qif_pipeline_job` run looked stale and `stuck_run_timeout_sensor` would request termination on every tick.
- Now treat non-positive numeric input the same as missing/invalid input and fall back to the configured default.

## Test plan
- [x] `uv run pytest tests/test_reporting_data_quality_checks.py -q`
- [x] `uv run pytest -q` (full suite, 57 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)