### PR TITLE
fix: harden QIF ingestion correctness

### DIFF
--- a/pipeline_personal_finance/assets.py
+++ b/pipeline_personal_finance/assets.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import pandas as pd
 import numpy as np
-import re
 from quiffen import Qif
 from dagster import (
     AssetDep,
@@ -18,6 +17,12 @@ from dagster_dbt import DagsterDbtTranslator, DbtCliResource, dbt_assets
 from sqlalchemy import text, JSON
 from typing import Any, Mapping, Optional
 from .constants import dbt_manifest_path, QIF_FILES
+from .qif_ingestion import (
+    add_filename_data_to_dataframe,
+    assert_unique_primary_keys,
+    sort_qif_files,
+    union_unique,
+)
 from .resources import SqlAlchemyClientResource
 
 # TODO: Incremental Refresh
@@ -146,46 +151,6 @@ def add_incremental_row_number(
     return df
 
 
-def validate_date_format(date_str: str) -> bool:
-    return bool(re.match(r"^\d{4}(0[1-9]|1[0-2])(0[1-9]|[12][0-9]|3[01])$", date_str))
-
-
-def add_filename_data_to_dataframe(
-    filename: str, dataframe: pd.DataFrame
-) -> pd.DataFrame:
-    base_name = filename.rsplit(".", 1)[0]
-
-    parts = base_name.split("_")
-
-    if len(parts) != 4 or parts[2] != "Transactions":
-        raise ValueError(
-            "Filename format must be 'BankName_AccountName_Transactions_YYYYMMDD"
-        )
-
-    bank_name, account_name, _, dates = parts
-
-    if not validate_date_format(dates):
-        raise ValueError(
-            f"Invalid date format in filename: {dates}. Must be in YYYYMMDD format"
-        )
-
-    dataframe["BankName"] = bank_name
-    dataframe["AccountName"] = account_name
-    dataframe["Extract_Date"] = dates
-
-    return dataframe
-
-
-def union_unique(
-    df1: pd.DataFrame, df2: pd.DataFrame, unique_column: str
-) -> Optional[pd.DataFrame]:
-    combined = pd.concat([df1, df2], ignore_index=True)
-
-    unique_combined = combined.drop_duplicates(subset=unique_column)
-
-    return unique_combined
-
-
 def verify_database_schema(
     context: AssetExecutionContext,
     personal_finance_database: SqlAlchemyClientResource,
@@ -250,7 +215,7 @@ def upload_dataframe_to_database(
     context: AssetExecutionContext, personal_finance_database: SqlAlchemyClientResource
 ):
     qif_filepath = Path(QIF_FILES)
-    qif_files = qif_filepath.glob("*.qif")
+    qif_files = sort_qif_files(qif_filepath.glob("*.qif"))
 
     grouped_dataframes = {}
 
@@ -270,33 +235,31 @@ def upload_dataframe_to_database(
         key = (bank_name, account_name)
 
         if key in grouped_dataframes:
-            print(
-                f"Combining data for bank: {bank_name}, account: {account_name}, for extract date: {extract_date}"
-            )
-            context.log.debug(
-                f"BankName: {bank_name}; AccountName: {account_name}; Extract_Date: {extract_date}"
+            context.log.info(
+                f"Combining data for bank={bank_name} account={account_name} "
+                f"extract_date={extract_date}"
             )
             grouped_dataframes[key] = union_unique(
-                grouped_dataframes[key], df_filename, unique_column="primary_key"
+                grouped_dataframes[key],
+                df_filename,
+                unique_column="primary_key",
             )
         else:
             grouped_dataframes[key] = df_filename
 
     for (bank, account), dataframe in grouped_dataframes.items():
-        if dataframe["primary_key"].is_unique:
-            print("no duplicates found")
-        else:
-            duplicates = dataframe[
-                dataframe.duplicated(subset="primary_key", keep=False)
-            ]
-            print(f"Duplicate rows: \n{duplicates}")
-            context.log.error(f"{bank}; {account}, duplicate rows: \n{duplicates}")
-            # raise ValueError("The primary key contains duplicate values")
+        assert_unique_primary_keys(
+            dataframe,
+            "primary_key",
+            bank_name=bank,
+            account_name=account,
+        )
 
-        print(f"Final dataframe for bank: {bank}, account: {account}")
-        print(dataframe.head())
-        unique_extract_dates = dataframe["Extract_Date"].unique()
-        print(f"Unique dates: {unique_extract_dates}")
+        unique_extract_dates = dataframe["Extract_Date"].unique().tolist()
+        context.log.info(
+            f"Prepared {len(dataframe)} rows for bank={bank} account={account} "
+            f"across extract dates={unique_extract_dates}"
+        )
 
         table_name = bank + "_" + account + "_Transactions"
 

--- a/pipeline_personal_finance/qif_ingestion.py
+++ b/pipeline_personal_finance/qif_ingestion.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+_QIF_FILENAME_PATTERN = re.compile(
+    r"^(?P<bank_name>[^_]+)_(?P<account_name>.+)_Transactions_(?P<extract_date>\d{8})$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QifFilenameParts:
+    bank_name: str
+    account_name: str
+    extract_date: str
+
+
+def validate_date_format(date_str: str) -> bool:
+    try:
+        parsed = dt.datetime.strptime(date_str, "%Y%m%d")
+    except ValueError:
+        return False
+    return parsed.strftime("%Y%m%d") == date_str
+
+
+def parse_qif_filename(filename: str | Path) -> QifFilenameParts:
+    stem = Path(filename).stem
+    match = _QIF_FILENAME_PATTERN.fullmatch(stem)
+    if not match:
+        raise ValueError(
+            "Filename format must be 'BankName_AccountName_Transactions_YYYYMMDD.qif'"
+        )
+
+    extract_date = match.group("extract_date")
+    if not validate_date_format(extract_date):
+        raise ValueError(
+            f"Invalid date format in filename: {extract_date}. Must be a real YYYYMMDD date"
+        )
+
+    return QifFilenameParts(
+        bank_name=match.group("bank_name"),
+        account_name=match.group("account_name"),
+        extract_date=extract_date,
+    )
+
+
+def add_filename_data_to_dataframe(filename: str, dataframe: pd.DataFrame) -> pd.DataFrame:
+    parts = parse_qif_filename(filename)
+    dataframe["BankName"] = parts.bank_name
+    dataframe["AccountName"] = parts.account_name
+    dataframe["Extract_Date"] = parts.extract_date
+    return dataframe
+
+
+def sort_qif_files(files: Iterable[Path]) -> list[Path]:
+    return sorted(
+        files,
+        key=lambda file_path: (
+            parse_qif_filename(file_path.name).extract_date,
+            file_path.name.lower(),
+        ),
+    )
+
+
+def union_unique(
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    unique_column: str,
+    *,
+    order_column: str = "Extract_Date",
+) -> pd.DataFrame:
+    combined = pd.concat([df1, df2], ignore_index=True)
+
+    if order_column in combined.columns:
+        combined = combined.sort_values(by=[order_column], kind="stable")
+        return combined.drop_duplicates(subset=unique_column, keep="last")
+
+    return combined.drop_duplicates(subset=unique_column)
+
+
+def duplicate_key_summary(
+    dataframe: pd.DataFrame,
+    unique_column: str,
+    *,
+    limit: int = 5,
+) -> str:
+    duplicates = dataframe[dataframe.duplicated(subset=unique_column, keep=False)]
+    if duplicates.empty:
+        return ""
+
+    sample_keys = duplicates[unique_column].drop_duplicates().head(limit).tolist()
+    key_list = ", ".join(str(key) for key in sample_keys)
+    return (
+        f"{len(duplicates)} duplicate rows across "
+        f"{duplicates[unique_column].nunique()} duplicate keys"
+        f"; sample keys: {key_list}"
+    )
+
+
+def assert_unique_primary_keys(
+    dataframe: pd.DataFrame,
+    unique_column: str,
+    *,
+    bank_name: str,
+    account_name: str,
+) -> None:
+    summary = duplicate_key_summary(dataframe, unique_column)
+    if summary:
+        raise ValueError(
+            f"Duplicate primary keys detected for {bank_name}/{account_name}: {summary}"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pandas>=2.2.0",
     "pytest>=9.0.2",
     "sqlfluff>=3.3.0",
     "sqlfluff-templater-dbt>=3.3.0",

--- a/tests/test_qif_ingestion.py
+++ b/tests/test_qif_ingestion.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pipeline_personal_finance.qif_ingestion import (
+    add_filename_data_to_dataframe,
+    assert_unique_primary_keys,
+    parse_qif_filename,
+    sort_qif_files,
+    union_unique,
+    validate_date_format,
+)
+
+
+def test_validate_date_format_rejects_impossible_calendar_dates():
+    assert validate_date_format("20260228") is True
+    assert validate_date_format("20260230") is False
+    assert validate_date_format("20261301") is False
+
+
+def test_parse_qif_filename_allows_underscores_in_account_name():
+    parts = parse_qif_filename("ING_My_New_Account_Transactions_20260422.qif")
+
+    assert parts.bank_name == "ING"
+    assert parts.account_name == "My_New_Account"
+    assert parts.extract_date == "20260422"
+
+
+def test_parse_qif_filename_rejects_invalid_structure_with_clear_error():
+    with pytest.raises(
+        ValueError,
+        match=r"Filename format must be 'BankName_AccountName_Transactions_YYYYMMDD\.qif'",
+    ):
+        parse_qif_filename("ING_Countdown_20260422.qif")
+
+
+def test_parse_qif_filename_rejects_impossible_dates_with_clear_error():
+    with pytest.raises(
+        ValueError,
+        match=r"Invalid date format in filename: 20260230\. Must be a real YYYYMMDD date",
+    ):
+        parse_qif_filename("ING_Countdown_Transactions_20260230.qif")
+
+
+def test_add_filename_data_to_dataframe_adds_metadata_columns():
+    dataframe = pd.DataFrame({"amount": [10.5]})
+
+    enriched = add_filename_data_to_dataframe(
+        "ING_Countdown_Transactions_20260422.qif", dataframe.copy()
+    )
+
+    assert enriched.loc[0, "BankName"] == "ING"
+    assert enriched.loc[0, "AccountName"] == "Countdown"
+    assert enriched.loc[0, "Extract_Date"] == "20260422"
+
+
+def test_sort_qif_files_orders_by_extract_date_then_name():
+    files = [
+        Path("ING_Countdown_Transactions_20260422.qif"),
+        Path("Adelaide_Offset_Transactions_20260419.qif"),
+        Path("Adelaide_Homeloan_Transactions_20260419.qif"),
+    ]
+
+    ordered = sort_qif_files(files)
+
+    assert [path.name for path in ordered] == [
+        "Adelaide_Homeloan_Transactions_20260419.qif",
+        "Adelaide_Offset_Transactions_20260419.qif",
+        "ING_Countdown_Transactions_20260422.qif",
+    ]
+
+
+def test_union_unique_prefers_latest_extract_for_duplicate_primary_key():
+    earlier = pd.DataFrame(
+        {
+            "primary_key": ["dup", "older-only"],
+            "Extract_Date": ["20260420", "20260420"],
+            "memo": ["stale", "still here"],
+        }
+    )
+    later = pd.DataFrame(
+        {
+            "primary_key": ["dup", "new-only"],
+            "Extract_Date": ["20260422", "20260422"],
+            "memo": ["fresh", "new row"],
+        }
+    )
+
+    merged = union_unique(earlier, later, "primary_key")
+    merged_by_key = merged.set_index("primary_key")
+
+    assert list(merged["primary_key"]) == ["older-only", "dup", "new-only"]
+    assert merged_by_key.loc["dup", "Extract_Date"] == "20260422"
+    assert merged_by_key.loc["dup", "memo"] == "fresh"
+
+
+def test_assert_unique_primary_keys_raises_helpful_error():
+    dataframe = pd.DataFrame(
+        {
+            "primary_key": ["dup", "dup", "unique"],
+            "Extract_Date": ["20260422", "20260422", "20260422"],
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"Duplicate primary keys detected for ING/Countdown") as exc:
+        assert_unique_primary_keys(
+            dataframe,
+            "primary_key",
+            bank_name="ING",
+            account_name="Countdown",
+        )
+
+    assert "sample keys: dup" in str(exc.value)

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ dependencies = [
     { name = "parsedatetime" },
     { name = "python-slugify" },
     { name = "pytimeparse" },
-    { name = "tzdata", marker = "platform_system == 'Windows'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/77/6f5df1c68bf056f5fdefc60ccc616303c6211e71cd6033c830c12735f605/agate-1.9.1.tar.gz", hash = "sha256:bc60880c2ee59636a2a80cd8603d63f995be64526abf3cbba12f00767bcd5b3d", size = 202303 }
 wheels = [
@@ -227,7 +227,7 @@ name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065 }
 wheels = [
@@ -281,10 +281,10 @@ dependencies = [
     { name = "grpcio-health-checking" },
     { name = "jinja2" },
     { name = "protobuf" },
-    { name = "psutil", marker = "platform_system == 'Windows'" },
+    { name = "psutil", marker = "sys_platform == 'win32'" },
     { name = "python-dotenv" },
     { name = "pytz" },
-    { name = "pywin32", marker = "platform_system == 'Windows'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "rich" },
     { name = "setuptools" },
@@ -2065,14 +2065,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906 },
     { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607 },
     { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769 },
-    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441 },
-    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291 },
-    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632 },
-    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905 },
-    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495 },
-    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388 },
-    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879 },
-    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017 },
     { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351 },
     { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363 },
     { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615 },
@@ -2289,6 +2281,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pandas" },
     { name = "pytest" },
     { name = "sqlfluff" },
     { name = "sqlfluff-templater-dbt" },
@@ -2304,6 +2297,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pandas", specifier = ">=2.2.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "sqlfluff", specifier = ">=3.3.0" },
     { name = "sqlfluff-templater-dbt", specifier = ">=3.3.0" },
@@ -2976,7 +2970,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598 }
 wheels = [


### PR DESCRIPTION
## Summary

This PR hardens QIF ingestion correctness around file parsing, merge ordering, and duplicate handling.

### Changes
- validate QIF extract dates as real calendar dates, not just regex-shaped strings
- parse filenames from the right so account names can safely contain underscores
- sort QIF files deterministically by extract date, then filename
- when deduplicating merged extracts, prefer the newest `Extract_Date`
- fail fast on duplicate `primary_key` values instead of only printing debug output
- replace ingestion `print(...)` debugging with Dagster structured logging
- add focused unit tests for the extracted ingestion helpers
- add `pandas` to the root dev dependencies so `uv run pytest -q` can import the newly tested ingestion module

## Why

The previous ingestion path had a few correctness holes:
- impossible dates like `20260230` could pass filename validation
- filenames with underscores in the account name would fail parsing
- QIF file iteration order depended on filesystem ordering
- duplicate keys were logged but not enforced
- `union_unique()` kept whichever duplicate happened to appear first, rather than explicitly preferring the newest extract

Together, these changes make the landing-table refresh more deterministic and safer to operate.

## Validation

- `uv sync --frozen`
- `uv run pytest -q` ✅ (65 passed)
- `uv run python -m py_compile pipeline_personal_finance/assets.py pipeline_personal_finance/qif_ingestion.py tests/test_qif_ingestion.py` ✅
- `uv run sqlfluff lint pipeline_personal_finance/dbt_finance/models/ --dialect postgres` ⚠️ still reports many pre-existing dbt SQL/style/template issues in the repo, and CI already marks that job `continue-on-error`

## Notes

- No API surface changes intended.
- I intentionally kept this PR scoped to ingestion correctness rather than broader dbt/model architecture changes.
