### PR TITLE
[codex] add Context7 Codex guidance

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,4 @@
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@upstash/context7-mcp"
+        "@upstash/context7-mcp@latest"
       ],
       "env": {}
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Codex Project Notes
+
+Use this file as the Codex entry point for repository-specific guidance. Keep detailed workflow notes in the referenced files and inspect only the files needed for the active task.
+
+## Context Loading
+
+- Start with `README.md`, this file, and the scoped files needed for the request.
+- For current Dagster, dbt, or Grafana documentation, use the project-local Context7 MCP server configured in `.codex/config.toml`.
+- See `docs/context7-codex.md` for the Context7 library IDs and when to prefer Context7 versus local repository inspection.
+- For dbt-only work, also read `pipeline_personal_finance/dbt_finance/AGENTS.md`.
+
+## Project Rules
+
+- Prefer `make <target>` from the repository root over raw `docker compose`, `dbt`, or `uv` commands.
+- Normal pipeline execution is Dagster-first: `make dagster-run`.
+- Direct dbt build/test is break-glass only: `ALLOW_DIRECT_DBT=1 make dbt-build` or `ALLOW_DIRECT_DBT=1 make dbt-test`.
+- Do not edit private data, `.env` secrets, QIF files, generated db files, `target/`, `logs/`, screenshots, or local backup files unless explicitly requested.
+- Keep fixes scoped and verify with the narrowest relevant command before calling work complete.

--- a/docs/context7-codex.md
+++ b/docs/context7-codex.md
@@ -1,0 +1,17 @@
+# Context7 For Codex
+
+This project has a local Context7 MCP server for Codex in `.codex/config.toml`, mirrored for JSON-based MCP clients in `.mcp.json`. Use it for current external documentation when Dagster, dbt, or Grafana behavior matters.
+
+## Library IDs
+
+- Dagster: `/dagster-io/dagster`
+- dbt docs: `/dbt-labs/docs.getdbt.com`
+- Grafana docs: `/websites/grafana`
+
+## Routing Rule
+
+Use Context7 for questions about current APIs, options, schemas, configuration keys, examples, and version-sensitive behavior. Typical examples: Dagster asset/resource APIs, `dagster-dbt`, dbt model/test/profile configuration, materializations, Grafana dashboard JSON, panel options, provisioning, data source query behavior, and units.
+
+Use local repository inspection for project truth: `Makefile` targets, Docker Compose wiring, Dagster definitions, dbt models/macros/tests, dashboard JSON, scripts, fixtures, and existing conventions. Local code decides what this project currently does.
+
+Best workflow: inspect the local repo enough to identify the exact component and project convention, query Context7 for current external docs when needed, then reconcile the docs with the local implementation. Keep Context7 prompts documentation-focused and do not send secrets, private data, or raw QIF content.


### PR DESCRIPTION
## Summary

Adds repository guidance for Codex and configures the project-local Context7 MCP server in both Codex TOML and JSON MCP client formats.

## Details

- Adds `AGENTS.md` as the repository entry point for Codex-specific workflow rules.
- Adds `docs/context7-codex.md` with Context7 library IDs and routing guidance.
- Adds `.codex/config.toml` for Codex MCP configuration.
- Pins the existing `.mcp.json` Context7 package reference to `@latest` to match the Codex config.

## Validation

- `python -m json.tool .mcp.json >/dev/null`
- `python -c "import tomllib; tomllib.load(open('.codex/config.toml','rb'))"`